### PR TITLE
Refactor rulesets

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,4 +1,29 @@
 ---
 .travis.yml:
+  extras:
+    - rvm: 2.4.0
+      env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
+      services: docker
+      sudo: required
+      bundler_args: --without development
+      dist: trusty
+    - rvm: 2.4.0
+      env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/debian-9
+      services: docker
+      sudo: required
+      bundler_args: --without development
+      dist: trusty
+    - rvm: 2.4.0
+      env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+      services: docker
+      sudo: required
+      bundler_args: --without development
+      dist: trusty
+    - rvm: 2.4.0
+      env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04
+      services: docker
+      sudo: required
+      bundler_args: --without development
+      dist: trusty
   secure: "d532jz5QRujx8orG3QPdhtU6bYOkEpSqj4AeC2h8cyDyyzi0JcbnTWUmhpx69jcS7WvAkj4fPYdYQbE/OxdgFegVaG5jmvG0rfFOPJsLKpgXKAHy3cCS2VFQcNXUHwFoDbTxW13aemR1Qy7Cw+WvnNzgoCoL1vTSGR/T81k5+tBfScQIzM7rs5fVctxNngWij7iEQSU2NQKCwhPB80G5ZdN4INb+K69sDKu4KkybulzrYEI6ZPX6FGEImkGf3ub8Qa3o3wy3l3bknxDfqi1WYdict8WZdr/et9hUIicLdLEypCCAzsc7fLKzVrfuXJMvivaFW2VMes1c/cVHBC5c+9eFP/vTREGa7HeWuvhLTTUUc5gzfUPYIbdAaulQs+cXaoWouTThZN7JEL1XZRZQ7vhbSylob+6UeKc27vmjL37kixY3iUN0hIumvpKQDB27tvJHcH6JAxZ8UWZ/VIeenqalLWFHyLe8GJnHkKHdCllW7cl0bVL9HR+1HY2RHJgCR7oWi/+CCn+0D48D1hx88gH9nXk6E9RXbTRlE4bZFs0Q0EGF1j6vNNwDtZO1cPeJnwM0LX3jSLL1uS1O2oeR+V66sFDCEccYtPZOPsIz3fcQPHv+Cfv7KlHrIn24YIPT6EI6VdhEAzuFfVMOWnAq0qAL5J8rjF6ssZK6QvTm/sA="
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,30 @@ matrix:
   - rvm: 2.4.2
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/centos-7
+    services: docker
+    sudo: required
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/debian-9
+    services: docker
+    sudo: required
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-14.04
+    services: docker
+    sudo: required
+  - rvm: 2.4.0
+    bundler_args: --without development
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent CHECK=acceptance BEAKER_debug=true BEAKER_set=docker/ubuntu-16.04
+    services: docker
+    sudo: required
 branches:
   only:
   - master

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,69 @@
   "source": "https://github.com/voxpupuli/puppet-rsyslog",
   "project_page": "https://github.com/voxpupuli/puppet-rsyslog",
   "issues_url": "https://github.com/voxpupuli/puppet-rsyslog/issues",
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Scientific",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "14.04",
+        "16.04"
+      ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "10",
+        "11",
+        "12"
+      ]
+    },
+    {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.1"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "25"
+      ]
+    }
+  ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",

--- a/spec/acceptance/ruleset_spec.rb
+++ b/spec/acceptance/ruleset_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+
+describe 'rsyslog::component::ruleset' do
+  it 'applies' do
+    pp = <<-MANIFEST
+      class { 'rsyslog::server':
+        rulesets => {
+          'ruleset_eth0_514_test' => {
+            'parameters' => {
+              'queue.size' => '10000',
+            },
+            'rules' => [
+              {
+                'property_filter' => {
+                  'name'     => 'test_property_filter',
+                  'property' => 'msg',
+                  'operator' => 'contains',
+                  'value'    => 'error',
+                  'tasks'    => {
+                    'call'     => 'action.ruleset.test',
+                    'stop'     => true
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    MANIFEST
+
+    apply_manifest(pp, catch_failures: true)
+    apply_manifest(pp, catch_changes: true)
+  end
+
+  describe file('/etc/rsyslog.d/50_rsyslog.conf') do
+    it { is_expected.to be_file }
+    it { is_expected.to be_readable }
+    its(:content) { is_expected.to match(%r{# ruleset_eth0_514_test ruleset\nruleset \(name="ruleset_eth0_514_test"\n\s*queue\.size="10000"\n\) {\n# test_property_filter\n:msg, contains, "error" {\ncall action.ruleset.test\nstop\n\s*}\n\n}})}
+  end
+end

--- a/spec/acceptance/ruleset_spec.rb
+++ b/spec/acceptance/ruleset_spec.rb
@@ -35,6 +35,6 @@ describe 'rsyslog::component::ruleset' do
   describe file('/etc/rsyslog.d/50_rsyslog.conf') do
     it { is_expected.to be_file }
     it { is_expected.to be_readable }
-    its(:content) { is_expected.to match(%r{# ruleset_eth0_514_test ruleset\nruleset \(name="ruleset_eth0_514_test"\n\s*queue\.size="10000"\n\) {\n# test_property_filter\n:msg, contains, "error" {\ncall action.ruleset.test\nstop\n\s*}\n\n}})}
+    its(:content) { is_expected.to match(%r{# ruleset_eth0_514_test ruleset\nruleset \(name="ruleset_eth0_514_test"\n\s*queue\.size="10000"\n\) {\n# test_property_filter\n:msg, contains, "error" {\ncall action\.ruleset\.test\nstop\n\s*}\n\n}}) }
   end
 end

--- a/spec/defines/component/expression_filter_spec.rb
+++ b/spec/defines/component/expression_filter_spec.rb
@@ -42,7 +42,7 @@ describe 'rsyslog::component::expression_filter', include_rsyslog: true do
       is_expected.to contain_concat__fragment('rsyslog::component::expression_filter::myexpressionfilter').with_content(
         <<-CONTENT
 # myexpressionfilter
-if msg == "test" {
+if msg == "test" then {
 # myaction
 action(type="omfile"
   dynaFile="remoteSyslog"

--- a/spec/defines/component/ruleset_spec.rb
+++ b/spec/defines/component/ruleset_spec.rb
@@ -201,6 +201,7 @@ ruleset (name="myruleset"
         rules: [
           {
             'property_filter' => {
+              'name'     => 'mypropertyfilter',
               'property' => 'msg',
               'operator' => 'contains',
               'value'    => 'error',
@@ -222,10 +223,12 @@ ruleset (name="myruleset"
   parser="pmrfc3164.hostname_with_slashes"
   queue.size="10000"
 ) {
-  :msg, contains, "error" {
-    call action.ruleset.test
-    stop
+# mypropertyfilter
+:msg, contains, "error" {
+call action.ruleset.test
+stop
   }
+
 }
       EOF
       )

--- a/spec/defines/component/ruleset_spec.rb
+++ b/spec/defines/component/ruleset_spec.rb
@@ -154,13 +154,14 @@ EOF
         rules: [
           {
             'expression_filter' => {
-              'if' => {
-                'filter'     => '$hostname',
-                'operator'   => '==',
-                'expression' => 'rsyslog_test',
-                'tasks'      => {
-                  'call'        => 'action.ruleset.test',
-                  'stop'        => true
+              'name' => 'myexpressionfilter',
+              'filter' => {
+                'if' => {
+                  'expression' => '$hostname == "rsyslog_test"',
+                  'tasks'      => {
+                    'call'        => 'action.ruleset.test',
+                    'stop'        => true
+                  }
                 }
               }
             }
@@ -177,9 +178,10 @@ ruleset (name="myruleset"
   parser="pmrfc3164.hostname_with_slashes"
   queue.size="10000"
 ) {
-  if ($hostname == 'rsyslog_test') then {
-    call action.ruleset.test
-    stop
+# myexpressionfilter
+if $hostname == "rsyslog_test" then {
+call action.ruleset.test
+stop
   }
 }
       EOF

--- a/spec/defines/component/ruleset_spec.rb
+++ b/spec/defines/component/ruleset_spec.rb
@@ -76,7 +76,8 @@ ruleset (name="myruleset"
   parser="pmrfc3164.hostname_with_slashes"
   queue.size="10000"
 ) {
-  set $.srv = lookup("srv-map", $fromhost-ip);
+
+set $.srv = lookup("srv-map", $fromhost-ip);
 }
 EOS
       )
@@ -97,8 +98,11 @@ EOS
         rules: [
           {
             'action' => {
-              'name' => 'utf8-fix',
-              'type' => 'mmutf8fix'
+              'name'   => 'utf8-fix',
+              'type'   => 'mmutf8fix',
+              'config' => {
+                'file' => '/var/log/fix'
+              }
             }
           },
           {
@@ -123,16 +127,19 @@ ruleset (name="myruleset"
   parser="pmrfc3164.hostname_with_slashes"
   queue.size="10000"
 ) {
-  # utf8-fix action
-  action(type="mmutf8fix"
-    name="utf8-fix"
-  )
-  # myaction2 action
-  action(type="omfile"
-    name="myaction2"
-    dynaFile="remoteSyslog"
-    specifics="/var/log/test"
-  )
+
+# utf8-fix
+action(type="mmutf8fix"
+  file="/var/log/fix"
+)
+
+
+# myaction2
+action(type="omfile"
+  dynaFile="remoteSyslog"
+  specifics="/var/log/test"
+)
+
   stop
 }
 EOF

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,9 +6,6 @@ require 'beaker/module_install_helper'
 run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
 
 RSpec.configure do |c|
-  # Project root
-  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Configure all nodes in nodeset
   c.before :suite do
     install_module_on(hosts)

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,17 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    install_module_on(hosts)
+    install_module_dependencies_on(hosts)
+  end
+end

--- a/templates/expression_filter.epp
+++ b/templates/expression_filter.epp
@@ -7,7 +7,7 @@ $conditionals
   <%- if $conditional == 'else' { -%>
 <%= $conditional %> {
   <%- } else { -%>
-<%= "${conditional} ${options['expression']}" %> {
+<%= "${conditional} ${options['expression']} then" %> {
   <%-}-%>
 <%= epp('rsyslog/tasks.epp', { 'tasks' => $options['tasks'] }) -%>
 }

--- a/templates/ruleset.epp
+++ b/templates/ruleset.epp
@@ -10,18 +10,18 @@ ruleset (name="<%= $ruleset_name %>"
   <%= $key %>="<%= $value %>"<%-%>
 <%}-%>
 ) {
-<% $rules.each |$rule| { -%>
-  <% $rule.each |$key, $params| { -%>
-    <% if $key == 'property_filter' { -%>
+<%- $rules.each |$rule| { -%>
+  <%- $rule.each |$key, $params| { -%>
+    <%- if $key == 'property_filter' { -%>
 <%= epp('rsyslog/property_filter.epp', { 'filter_name' => $params['name'], 'property' => $params['property'], 'operator' => $params['operator'], 'value' => $params['value'], 'tasks' => $params['tasks']}) %>
-    <% } elsif $key == 'expression_filter' { -%>
+    <%- } elsif $key == 'expression_filter' { -%>
 <%= epp('rsyslog/expression_filter.epp', { 'filter_name' => $params['name'], 'conditionals' => $params['filter'] }) -%>
-    <% } else {  %>
+    <%- } else {  %>
 <%= epp('rsyslog/tasks.epp', { 'tasks' => $rule }) -%>
-    <%}-%>
-  <%}-%>
-<%}-%>
-<% if $stop { -%>
+    <%-}-%>
+  <%-}-%>
+<%-}-%>
+<%- if $stop { -%>
   stop
-<% }-%>
+<%-}-%>
 }

--- a/templates/ruleset.epp
+++ b/templates/ruleset.epp
@@ -13,39 +13,7 @@ ruleset (name="<%= $ruleset_name %>"
 <% $rules.each |$rule| { -%>
 <%   $rule.each |$key, $params| { -%>
 <%     if $key == 'property_filter' { -%>
-  :<%= $params['property'] %>, <%= $params['operator'] %>, "<%= $params['value'] %>" {
-<%       $params['tasks'].each |$task, $value| { -%>
-<%         if $task == 'call' { -%>
-    call <%= $value %>
-<%         } elsif $task == 'stop' { -%>
-    stop
-<%         } elsif $task == 'set' { -%>
-<%           $task.each |$var, $value| { -%>
-    set $.<%= $var %> = <%= $value %><%-%>;
-<%           } -%>
-<%         } elsif $task == 'action' { -%>
-<%     if $params['facility'] { -%>
-<%= sprintf( '%-30s %s%s%s', $params['facility'], 'action(type="',$params['type'],'" ' )%>
-<%= sprintf('%33s%-s="%s"',' ','name',$params['name'])%>
-<%       if $params['config'] { -%>
-<%         $params['config'].each |$k, $v| { -%>
-<%= sprintf('%33s%-s="%s"',' ',$k,$v)%>
-<%         }-%>
-<%       }-%>
-<%= sprintf('%32s',')') %>
-<%     } else { -%>
-    action(type="<%= $params['type'] %>"
-      name="<%= $params['name'] %>"
-<%       if $params['config'] { -%>
-<%         $params['config'].each |$k, $v| { -%>
-      <%= $k %>="<%= $v %>"
-<%         }-%>
-<%       }-%>
-    )
-<%     }-%>
-<%         }-%>
-<%       }-%>
-  }
+<%= epp('rsyslog/property_filter.epp', { 'filter_name' => $params['name'], 'property' => $params['property'], 'operator' => $params['operator'], 'value' => $params['value'], 'tasks' => $params['tasks']}) %>
 <%     } elsif $key == 'expression_filter' { -%>
 <%       $params.each |$conditional, $block| { -%>
 <%         if $conditional == 'else' { -%>

--- a/templates/ruleset.epp
+++ b/templates/ruleset.epp
@@ -11,45 +11,16 @@ ruleset (name="<%= $ruleset_name %>"
 <%}-%>
 ) {
 <% $rules.each |$rule| { -%>
-<%   $rule.each |$key, $params| { -%>
-<%     if $key == 'property_filter' { -%>
+  <% $rule.each |$key, $params| { -%>
+    <% if $key == 'property_filter' { -%>
 <%= epp('rsyslog/property_filter.epp', { 'filter_name' => $params['name'], 'property' => $params['property'], 'operator' => $params['operator'], 'value' => $params['value'], 'tasks' => $params['tasks']}) %>
-<%     } elsif $key == 'expression_filter' { -%>
+    <% } elsif $key == 'expression_filter' { -%>
 <%= epp('rsyslog/expression_filter.epp', { 'filter_name' => $params['name'], 'conditionals' => $params['filter'] }) -%>
-<%     } elsif $key == 'set' { -%>
-<%-       $params.each |$name, $value| { -%>
-<%= epp('rsyslog/set.epp', { 'name' => $name, 'value' => $value}) -%>
-<%        }-%>
-<%     } elsif $key == 'call' { -%>
-  call <%= $params %><%-%>
-<%     }-%>
-<%     elsif $key == 'lookup' { -%>
-  set $.<%= $params['var'] %> = lookup("<%= $params['lookup_table'] %>", <%= $params['expr'] %>);
-<%     }-%>
-<%     elsif $key == 'action' { -%>
-  # <%= $params['name'] %> action
-<%       if $params['facility'] { -%>
-<%= sprintf( '%-30s %s%s%s', $params['facility'], 'action(type="',$params['type'],'" ' )%>
-<%= sprintf('%33s%-s="%s"',' ','name',$params['name'])%>
-<%         if $params['config'] { -%>
-<%           $params['config'].each |$k, $v| { -%>
-<%= sprintf('%33s%-s="%s"',' ',$k,$v)%>
-<%           }-%>
-<%         }-%>
-<%= sprintf('%32s',')') %>
-<%       } else { -%>
-  action(type="<%= $params['type'] %>"
-    name="<%= $params['name'] %>"
-<%         if $params['config'] { -%>
-<%           $params['config'].each |$k, $v| { -%>
-    <%= $k %>="<%= $v %>"
-<%           }-%>
-<%         }-%>
-  )
-<%       }-%>
-<%     }-%>
-<%   }-%>
-<% }-%>
+    <% } else {  %>
+<%= epp('rsyslog/tasks.epp', { 'tasks' => $rule }) -%>
+    <%}-%>
+  <%}-%>
+<%}-%>
 <% if $stop { -%>
   stop
 <% }-%>

--- a/templates/ruleset.epp
+++ b/templates/ruleset.epp
@@ -15,52 +15,12 @@ ruleset (name="<%= $ruleset_name %>"
 <%     if $key == 'property_filter' { -%>
 <%= epp('rsyslog/property_filter.epp', { 'filter_name' => $params['name'], 'property' => $params['property'], 'operator' => $params['operator'], 'value' => $params['value'], 'tasks' => $params['tasks']}) %>
 <%     } elsif $key == 'expression_filter' { -%>
-<%       $params.each |$conditional, $block| { -%>
-<%         if $conditional == 'else' { -%>
-  else {
-<%         } else { -%>
-  <%= "${conditional} (${block['filter']} ${block['operator']} '${block['expression']}') " -%> then {
-<%         }-%>
-<%         $block['tasks'].each |$task, $value| { -%>
-<%           if $task == 'call' { -%>
-    call <%= $value %>
-<%           } elsif $task == 'stop' { -%>
-    stop
-<%           } elsif $task == 'set' { -%>
-<%             $task.each |$var, $value| { -%>
-    set $.<%= $var %> = <%= $value %><%-%>;
-<%             } -%>
-<%           } elsif $task == 'action' { -%>
-<%       if $params['facility'] { -%>
-<%= sprintf( '%-30s %s%s%s', $params['facility'], 'action(type="',$params['type'],'" ' )%>
-<%= sprintf('%33s%-s="%s"',' ','name',$params['name'])%>
-<%         if $params['config'] { -%>
-<%           $params['config'].each |$k, $v| { -%>
-<%= sprintf('%33s%-s="%s"',' ',$k,$v)%>
-<%           }-%>
-<%         }-%>
-<%= sprintf('%32s',')') %>
-<%       } else { -%>
-    action(type="<%= $params['type'] %>"
-      name="<%= $params['name'] %>"
-<%         if $params['config'] { -%>
-<%           $params['config'].each |$k, $v| { -%>
-      <%= $k %>="<%= $v %>"
-<%           }-%>
-<%         }-%>
-    )
-<%       }-%>
-<%           }-%>
-<%         }-%>
-  }
-<%       }-%>
-<%     }-%>
-<%     elsif $key == 'set' { -%>
-<%-      $params.each |$var, $value| { -%>
-  set $.<%= $var %> = <%= $value %><%-%>;
-<%       }-%>
-<%     }-%>
-<%     elsif $key == 'call' { -%>
+<%= epp('rsyslog/expression_filter.epp', { 'filter_name' => $params['name'], 'conditionals' => $params['filter'] }) -%>
+<%     } elsif $key == 'set' { -%>
+<%-       $params.each |$name, $value| { -%>
+<%= epp('rsyslog/set.epp', { 'name' => $name, 'value' => $value}) -%>
+<%        }-%>
+<%     } elsif $key == 'call' { -%>
   call <%= $params %><%-%>
 <%     }-%>
 <%     elsif $key == 'lookup' { -%>

--- a/templates/tasks.epp
+++ b/templates/tasks.epp
@@ -11,5 +11,7 @@ Hash $tasks
   <%- } elsif $config == 'action' { -%>
     <%- if $cfgval['facility'] == undef or '' { $facility = 'default' } else { $facility = $cfgval['faclility'] } -%>
 <%= epp('rsyslog/action.epp', { 'action_name' => $cfgval['name'], 'type' => $cfgval['type'], 'facility' => $facility, 'config' => $cfgval['config'],}) %>
-  <%-}-%>
+  <%-} elsif $config == 'stop' { -%>
+stop
+  <%}-%>
 <%-}-%>

--- a/templates/tasks.epp
+++ b/templates/tasks.epp
@@ -7,7 +7,9 @@ Hash $tasks
   <%- } elsif $config == 'lookup'{ -%>
 <%= epp('rsyslog/lookup.epp', { 'variable_name' => $cfgval['var'], 'lookup_table' => $cfgval['lookup_table'], 'lookup_expr' => $cfgval['expr'], }) %><%-%>
   <%- } elsif $config == 'set' { -%>
-<%= epp('rsyslog/set.epp', { 'name' => $cfgval['var_name'], 'value' => $cfgval['value'] }) %><%-%>
+    <%- $cfgval.each |$name, $value| { -%>
+<%= epp('rsyslog/set.epp', { 'name' => $name, 'value' => $value }) %><%-%>
+    <%}-%>
   <%- } elsif $config == 'action' { -%>
     <%- if $cfgval['facility'] == undef or '' { $facility = 'default' } else { $facility = $cfgval['faclility'] } -%>
 <%= epp('rsyslog/action.epp', { 'action_name' => $cfgval['name'], 'type' => $cfgval['type'], 'facility' => $facility, 'config' => $cfgval['config'],}) %>


### PR DESCRIPTION
The Ruleset EPP template has been refactored for readability and
reduced duplication. The template now calls other templates to fill
out its configuration data for all values except the global ruleset
stop option.

closes #32, #41, and #42