### PR TITLE
Set concat order numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,7 @@ rsyslog::legacy_config_priority: 80
 rsyslog::custom_priority: 90
 ```
 
-Ordering uses the `order` attribute from [puppetlabs-concat](https://forge.puppet.com/puppetlabs/concat)'s `concat::fragment` defined type. This means that the ordering numbers are limited to integers between `0..99`. Any additional digits after the first two will be utilized to "sub-order" the base first two digits.
-
-Example:
-
-`priority => 111` will order after a priority of `10` but before a priority of `20`. Likewise, a priority of `112` will order after a priority of `111`, but before a priority of `20`. A priority of `60` still comes after a priority of `59`. This is a limitation of the attributes provided by [puppetlabs-concat](https://forge.puppet.com/puppetlabs/concat).
+Ordering is done numerically. I.E. 111 is after 110 is after 99.
 
 ### Configuring Objects
 

--- a/manifests/generate_concat.pp
+++ b/manifests/generate_concat.pp
@@ -7,12 +7,14 @@ define rsyslog::generate_concat (
       concat { "${confdir}/${target}":
         owner  => 'root',
         notify => Service[$::rsyslog::service_name],
+        order  => 'numeric',
       }
     }
   } else {
     if ! defined(Concat["${confdir}/${target}"]) {
       concat { "${confdir}/${target}":
         owner => 'root',
+        order => 'numeric',
       }
     }
   }

--- a/spec/acceptance/inputs_spec.rb
+++ b/spec/acceptance/inputs_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper_acceptance'
+
+describe 'Rsyslog inputs' do
+  before(:context) do
+    cleanup_helper
+  end
+
+  context 'basic input' do
+    it 'applies with inputs' do
+      pp = <<-MANIFEST
+      class { 'rsyslog::server':
+        inputs => {
+          'imudp' => {
+            'type'  => 'imudp',
+            'config' => {
+              'port' => '514',
+            },
+          },
+          'imptcp' => {
+            'type'  => 'imptcp',
+            'config' => {
+              'port' => '514',
+            },
+          },
+        },
+      }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/rsyslog.d/50_rsyslog.conf') do
+      its(:content) { is_expected.to contain('input\(type="imudp"\n\s*port="514"\n\)') }
+      its(:content) { is_expected.to contain('input\(type="imptcp"\n\s*port="514"\n\)') }
+    end
+  end
+
+  context 'inputs with custom priorities' do
+    it 'applies with custom priorities' do
+      pp = <<-MANIFEST
+class { 'rsyslog::server':
+        inputs => {
+          'imfile' => {
+            'priority' => 10,
+            'type'     => 'imfile',
+            'config'   => {
+              'File' => '/tmp/test-file',
+            },
+          },
+          'imudp' => {
+            'priority' => 111,
+            'type'     => 'imudp',
+            'config'   => {
+              'port' => '514',
+            },
+          },
+          'imptcp' => {
+            'priority' => 112,
+            'type'     => 'imptcp',
+            'config'   => {
+              'port' => '514',
+            },
+          },
+          'imfile2' => {
+            'priority' => 50,
+            'type'     => 'imfile',
+            'config'   => {
+              'File' => '/tmp/test-file2',
+            },
+          },
+        },
+      }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe file('/etc/rsyslog.d/50_rsyslog.conf') do
+      its(:content) { is_expected.to contain('input\(type="imfile"\n\s*File="/tmp/test-file"\n\)\n# imfile2\n') }
+      its(:content) { is_expected.to contain('input\(type="imfile"\n\s*File="/tmp/test-file2"\n\)\n# imudp\n') }
+      its(:content) { is_expected.to contain('input\(type="imudp"\n\s*port="514"\n\)\n# imptcp\n') }
+      its(:content) { is_expected.to contain('input\(type="imptcp"\n\s*port="514"\n\)\n') }
+    end
+  end
+end


### PR DESCRIPTION
Correctly addresses bug in #45 

This sets the concat ordering functionality to order `numerically` as that matches the original design of this module.
