### PR TITLE
Property filter operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not affect the functionality of the module.
 
-## [v2.2.1](https://github.com/voxpupuli/puppet-rsyslog/tree/v2.2.1) (2018-01-05)
+## [v2.2.1](https://github.com/voxpupuli/puppet-rsyslog/tree/v2.2.1) (2018-01-12)
 
 [Full Changelog](https://github.com/voxpupuli/puppet-rsyslog/compare/v2.2.0...v2.2.1)
 
@@ -15,6 +15,7 @@ These should not affect the functionality of the module.
 
 **Merged pull requests:**
 
+- Release 2.2.1 [\#52](https://github.com/voxpupuli/puppet-rsyslog/pull/52) ([dhollinger](https://github.com/dhollinger))
 - Set concat order numeric [\#51](https://github.com/voxpupuli/puppet-rsyslog/pull/51) ([dhollinger](https://github.com/dhollinger))
 - Updated docs to correctly reflect the priority functionality [\#50](https://github.com/voxpupuli/puppet-rsyslog/pull/50) ([dhollinger](https://github.com/dhollinger))
 - release 2.2.0 [\#49](https://github.com/voxpupuli/puppet-rsyslog/pull/49) ([bastelfreak](https://github.com/bastelfreak))

--- a/manifests/component/property_filter.pp
+++ b/manifests/component/property_filter.pp
@@ -3,7 +3,7 @@ define rsyslog::component::property_filter (
   String $target,
   String $confdir,
   String $property,
-  Enum[ 'contains', 'isequal', 'startswith', 'regex', 'ereregex'] $operator,
+  Enum[ 'contains', 'isequal', 'startswith', 'regex', 'ereregex', 'startswith_i', 'contains_i' ] $operator,
   String $value,
   Hash $tasks    = {},
   String $format = '<%= $content %>'

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-rsyslog",
-  "version": "2.2.1",
+  "version": "2.2.2-rc0",
   "author": "Vox Pupuli",
   "summary": "Manage rsyslog v8 configuration",
   "license": "Apache-2.0",


### PR DESCRIPTION
Add additional valid property filter operators
The property filter $operators parameter was missing two valid operators in the Enum data type - startswith_i and contains_i.