### PR TITLE
Test travis release fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,8 @@ notifications:
       - "chat.freenode.org#voxpupuli-notifications"
 deploy:
   provider: puppetforge
+  edge:
+    branch: puppet_forge-post-1_9_0
   user: puppet
   password:
     secure: "d532jz5QRujx8orG3QPdhtU6bYOkEpSqj4AeC2h8cyDyyzi0JcbnTWUmhpx69jcS7WvAkj4fPYdYQbE/OxdgFegVaG5jmvG0rfFOPJsLKpgXKAHy3cCS2VFQcNXUHwFoDbTxW13aemR1Qy7Cw+WvnNzgoCoL1vTSGR/T81k5+tBfScQIzM7rs5fVctxNngWij7iEQSU2NQKCwhPB80G5ZdN4INb+K69sDKu4KkybulzrYEI6ZPX6FGEImkGf3ub8Qa3o3wy3l3bknxDfqi1WYdict8WZdr/et9hUIicLdLEypCCAzsc7fLKzVrfuXJMvivaFW2VMes1c/cVHBC5c+9eFP/vTREGa7HeWuvhLTTUUc5gzfUPYIbdAaulQs+cXaoWouTThZN7JEL1XZRZQ7vhbSylob+6UeKc27vmjL37kixY3iUN0hIumvpKQDB27tvJHcH6JAxZ8UWZ/VIeenqalLWFHyLe8GJnHkKHdCllW7cl0bVL9HR+1HY2RHJgCR7oWi/+CCn+0D48D1hx88gH9nXk6E9RXbTRlE4bZFs0Q0EGF1j6vNNwDtZO1cPeJnwM0LX3jSLL1uS1O2oeR+V66sFDCEccYtPZOPsIz3fcQPHv+Cfv7KlHrIn24YIPT6EI6VdhEAzuFfVMOWnAq0qAL5J8rjF6ssZK6QvTm/sA="


### PR DESCRIPTION
Due to an issue with the current release of [Travis-CI/DPL](https://github.com/travis-ci/dpl) that is missing the `json-pure` gem from the Puppet Forge release process. 

This is the suggested workaround until the issue is fixed in DPL since we can't afford to halt releases waiting for Travis-CI