### PR TITLE
Switch datatype from Hash to array fo task param

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,8 +675,8 @@ rsyslog::server::rulesets:
           if:
             expression: '$fromhost-ip == "192.168.255.1"'
             tasks:
-              call: "ruleset.action.rawlog.standard"
-              stop: true
+              - call: "ruleset.action.rawlog.standard"
+              - stop: true
       - call: "ruleset.client.log.standard"
       - call: "ruleset.unknown.standard"
     stop: true
@@ -726,16 +726,16 @@ rsyslog::server::rulesets:
           if:
             expression: '$.srv == "windows"'
             tasks:
-              call: "ruleset.action.forward.windows"
-              stop: true
+              - call: "ruleset.action.forward.windows"
+              - stop: true
           "else if":
             expression: '$.srv == "unk"'
             tasks:
-              call: "ruleset.action.drop.unknown"
-              stop: true
+              - call: "ruleset.action.drop.unknown"
+              - stop: true
           else:
             tasks:
-              stop: true
+              - stop: true
     stop: true          
 ```
 
@@ -797,8 +797,8 @@ rsyslog::server::rulesets:
           operator: 'contains'
           value: 'error'
           tasks:
-            call: 'ruleset.action.error'
-            stop: true
+            - call: 'ruleset.action.error'
+            - stop: true
 ```
 
 Will Generate:
@@ -849,20 +849,20 @@ rsyslog::server::property_filters:
     operator: contains
     value: some_hostname
     tasks:
-      action:
-        name: omfile_defaults
-        type: omfile
-        facility: "*.*;auth,authpriv.none"
-          config:
-            dynaFile: "remoteSyslog"
-            specifics: "/var/log/test"
-      stop: true
+      - action:
+          name: omfile_defaults
+          type: omfile
+          facility: "*.*;auth,authpriv.none"
+            config:
+              dynaFile: "remoteSyslog"
+              specifics: "/var/log/test"
+      - stop: true
   ip_filter:
     property: fromhost-ip
     operator: startswith
     value: '192'
     tasks:
-      stop: true
+      - stop: true
 ```
 
 will produce
@@ -901,11 +901,11 @@ rsyslog::server::expression_filters:
       if:
         expression: '$msg contains "error"'
         tasks:
-          action:
-            name: omfile_error
-            type: omfile
-            config:
-              specifics: /var/log/errlog
+          - action:
+              name: omfile_error
+              type: omfile
+              config:
+                specifics: /var/log/errlog
 ```
 
 will produce
@@ -926,14 +926,14 @@ rsyslog::server::expression_filters:
     if:
       expression: '$syslogfacility-text == "local0" and $msg startswith "DEVNAME" and ($msg contains "error1" or $msg contains "error0")'
       tasks:
-        stop: true
+        - stop: true
     else:
       tasks:
-        action:
-          name: error_log
-          type: omfile
-          config:
-            specifics: /var/log/errlog
+        - action:
+            name: error_log
+            type: omfile
+            config:
+              specifics: /var/log/errlog
 ```
 
 will produce:

--- a/manifests/component/property_filter.pp
+++ b/manifests/component/property_filter.pp
@@ -5,7 +5,7 @@ define rsyslog::component::property_filter (
   String $property,
   Rsyslog::PropertyOperator $operator,
   String $value,
-  Hash $tasks    = {},
+  Array $tasks    = [],
   String $format = '<%= $content %>'
 ) {
   include rsyslog

--- a/spec/acceptance/expression_filter_spec.rb
+++ b/spec/acceptance/expression_filter_spec.rb
@@ -14,10 +14,10 @@ describe 'Rsyslog expression filters' do
             'conditionals' => {
               'if' => {
                 'expression' => 'msg == "test"',
-                'tasks' => {
-                  'call' => 'ruleset.action.test',
-                  'stop' => true,
-                }
+                'tasks' => [
+                  { 'call' => 'ruleset.action.test' },
+                  { 'stop' => true },
+                ]
               }
             }
           }

--- a/spec/acceptance/ruleset_spec.rb
+++ b/spec/acceptance/ruleset_spec.rb
@@ -18,10 +18,10 @@ describe 'Rsyslog::Component::Ruleset' do
                   'property' => 'msg',
                   'operator' => 'contains',
                   'value'    => 'error',
-                  'tasks'    => {
-                    'call'     => 'action.ruleset.test',
-                    'stop'     => true
-                  }
+                  'tasks'    => [
+                    { 'call'     => 'action.ruleset.test' },
+                    { 'stop'     => true }
+                  ]
                 }
               }
             ]

--- a/spec/defines/component/expression_filter_spec.rb
+++ b/spec/defines/component/expression_filter_spec.rb
@@ -14,24 +14,24 @@ describe 'rsyslog::component::expression_filter', include_rsyslog: true do
           if: {
             expression: 'msg == "test"',
             tasks: [
-              {action: {
+              { action: {
                 name: 'myaction',
                 type: 'omfile',
                 config: {
                   dynaFile: 'remoteSyslog'
                 }
-              }}
+              } }
             ]
           },
           else: {
             tasks: [
-              {action: {
+              { action: {
                 name: 'myaction2',
                 type: 'omfwd',
                 config: {
                   KeepAlive: 'on'
                 }
-              }}
+              } }
             ]
           }
         }

--- a/spec/defines/component/expression_filter_spec.rb
+++ b/spec/defines/component/expression_filter_spec.rb
@@ -13,26 +13,26 @@ describe 'rsyslog::component::expression_filter', include_rsyslog: true do
         conditionals: {
           if: {
             expression: 'msg == "test"',
-            tasks: {
-              action: {
+            tasks: [
+              {action: {
                 name: 'myaction',
                 type: 'omfile',
                 config: {
                   dynaFile: 'remoteSyslog'
                 }
-              }
-            }
+              }}
+            ]
           },
           else: {
-            tasks: {
-              action: {
+            tasks: [
+              {action: {
                 name: 'myaction2',
                 type: 'omfwd',
                 config: {
                   KeepAlive: 'on'
                 }
-              }
-            }
+              }}
+            ]
           }
         }
       }

--- a/spec/defines/component/property_filter_spec.rb
+++ b/spec/defines/component/property_filter_spec.rb
@@ -13,15 +13,17 @@ describe 'rsyslog::component::property_filter', include_rsyslog: true do
         property: 'msg',
         operator: 'contains',
         value: 'val',
-        tasks: {
-          action: {
-            name: 'myaction',
-            type: 'omfile',
-            config: {
-              dynaFile: 'remoteSyslog'
+        tasks: [
+          {
+            action: {
+              name: 'myaction',
+              type: 'omfile',
+              config: {
+                dynaFile: 'remoteSyslog'
+              }
             }
           }
-        }
+        ]
       }
     end
 
@@ -54,15 +56,15 @@ action(type="omfile"
         property: 'msg',
         operator: 'equals',
         value: 'val',
-        tasks: {
-          action: {
+        tasks: [
+          {action: {
             name: 'myaction',
             type: 'omfile',
             config: {
               dynaFile: 'remoteSyslog'
             }
-          }
-        }
+          }}
+        ]
       }
     end
 
@@ -80,15 +82,15 @@ action(type="omfile"
           property: 'msg',
           operator: operator,
           value: 'val',
-          tasks: {
-            action: {
+          tasks: [
+            {action: {
               name: 'myaction',
               type: 'omfile',
               config: {
                 dynaFile: 'remoteSyslog'
               }
-            }
-          }
+            }}
+          ]
         }
       end
 

--- a/spec/defines/component/property_filter_spec.rb
+++ b/spec/defines/component/property_filter_spec.rb
@@ -57,13 +57,13 @@ action(type="omfile"
         operator: 'equals',
         value: 'val',
         tasks: [
-          {action: {
+          { action: {
             name: 'myaction',
             type: 'omfile',
             config: {
               dynaFile: 'remoteSyslog'
             }
-          }}
+          } }
         ]
       }
     end
@@ -83,13 +83,13 @@ action(type="omfile"
           operator: operator,
           value: 'val',
           tasks: [
-            {action: {
+            { action: {
               name: 'myaction',
               type: 'omfile',
               config: {
                 dynaFile: 'remoteSyslog'
               }
-            }}
+            } }
           ]
         }
       end

--- a/spec/defines/component/ruleset_spec.rb
+++ b/spec/defines/component/ruleset_spec.rb
@@ -168,10 +168,10 @@ EOF
               'filter' => {
                 'if' => {
                   'expression' => '$hostname == "rsyslog_test"',
-                  'tasks'      => {
-                    'call'        => 'action.ruleset.test',
-                    'stop'        => true
-                  }
+                  'tasks'      => [
+                    { 'call'        => 'action.ruleset.test' },
+                    { 'stop'        => true }
+                  ]
                 }
               }
             }
@@ -216,10 +216,10 @@ stop
               'property' => 'msg',
               'operator' => 'contains',
               'value'    => 'error',
-              'tasks'    => {
-                'call'      => 'action.ruleset.test',
-                'stop'      => true
-              }
+              'tasks'    => [
+                { 'call'      => 'action.ruleset.test' },
+                { 'stop'      => true }
+              ]
             }
           }
         ]

--- a/templates/expression_filter.epp
+++ b/templates/expression_filter.epp
@@ -9,6 +9,8 @@ $conditionals
   <%- } else { -%>
 <%= "${conditional} ${options['expression']} then" %> {
   <%-}-%>
-<%= epp('rsyslog/tasks.epp', { 'tasks' => $options['tasks'] }) -%>
+<%- $options['tasks'].each |$task| { -%>
+<%= epp('rsyslog/tasks.epp', { 'tasks' => $task }) -%>
+<%-}-%>
 }
 <%}-%>

--- a/templates/property_filter.epp
+++ b/templates/property_filter.epp
@@ -1,11 +1,13 @@
 <%- |
 $filter_name,
-$property,
-$operator,
-$value,
-$tasks
+String $property,
+Rsyslog::PropertyOperator $operator,
+String $value,
+Array $tasks
 | -%>
 # <%= $filter_name %>
 :<%= $property %>, <%= $operator %>, "<%= $value %>" {
-<%= epp('rsyslog/tasks.epp', { 'tasks' => $tasks }) -%>
+<%- $tasks.each |$task|  { -%>
+<%= epp('rsyslog/tasks.epp', { 'tasks' => $task }) -%>
+<%-}-%>
 }

--- a/templates/tasks.epp
+++ b/templates/tasks.epp
@@ -1,5 +1,5 @@
 <%- |
-Hash $tasks
+$tasks
 | -%>
 <%- $tasks.each |$config, $cfgval| { -%>
   <%- if $config == 'call' { -%>


### PR DESCRIPTION
A Hash cannot contain two identical keys and since Rsyslog can have the same config option repeated, the task parameter related to filters needed to be updated to be an Array rather than a Hash.