### PR TITLE
Update metadata.json to remove hiera 4 and support Fedora

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -39,8 +39,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {
@@ -61,6 +61,12 @@
       "operatingsystemrelease": [
         "9"
       ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "28"
+      ]
     }
   ],
   "dependencies": [
@@ -78,6 +84,5 @@
       "name": "puppet",
       "version_requirement": ">= 4.10.0 < 6.0.0"
     }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
closes #95 and #84 