### PR TITLE
Add support to use upstream repos in Ubuntu and EL

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,7 @@ fixtures:
   repositories:
     concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
+    yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core.git'
   symlinks:
     rsyslog: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,5 @@ fixtures:
     concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
-    yumrepo_core: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core.git'
   symlinks:
     rsyslog: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,3 @@ fixtures:
     concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
     apt: 'https://github.com/puppetlabs/puppetlabs-apt.git'
-  symlinks:
-    rsyslog: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,9 +1,11 @@
 ---
 .travis.yml:
   docker_sets:
+    - set: centos6-64
     - set: centos7-64
+    - set: debian8-64
     - set: debian9-64
-    - set: ubuntu1404-64
     - set: ubuntu1604-64
+    - set: ubuntu1804-64
   secure: "d532jz5QRujx8orG3QPdhtU6bYOkEpSqj4AeC2h8cyDyyzi0JcbnTWUmhpx69jcS7WvAkj4fPYdYQbE/OxdgFegVaG5jmvG0rfFOPJsLKpgXKAHy3cCS2VFQcNXUHwFoDbTxW13aemR1Qy7Cw+WvnNzgoCoL1vTSGR/T81k5+tBfScQIzM7rs5fVctxNngWij7iEQSU2NQKCwhPB80G5ZdN4INb+K69sDKu4KkybulzrYEI6ZPX6FGEImkGf3ub8Qa3o3wy3l3bknxDfqi1WYdict8WZdr/et9hUIicLdLEypCCAzsc7fLKzVrfuXJMvivaFW2VMes1c/cVHBC5c+9eFP/vTREGa7HeWuvhLTTUUc5gzfUPYIbdAaulQs+cXaoWouTThZN7JEL1XZRZQ7vhbSylob+6UeKc27vmjL37kixY3iUN0hIumvpKQDB27tvJHcH6JAxZ8UWZ/VIeenqalLWFHyLe8GJnHkKHdCllW7cl0bVL9HR+1HY2RHJgCR7oWi/+CCn+0D48D1hx88gH9nXk6E9RXbTRlE4bZFs0Q0EGF1j6vNNwDtZO1cPeJnwM0LX3jSLL1uS1O2oeR+V66sFDCEccYtPZOPsIz3fcQPHv+Cfv7KlHrIn24YIPT6EI6VdhEAzuFfVMOWnAq0qAL5J8rjF6ssZK6QvTm/sA="
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,18 +28,6 @@ matrix:
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
@@ -47,18 +35,6 @@ matrix:
     bundler_args: --without development release
     dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
   - rvm: 2.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,37 @@ matrix:
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos6-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
     env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
   - rvm: 2.5.1
@@ -46,19 +70,7 @@ matrix:
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1404-64{hypervisor=docker} CHECK=beaker
-    services: docker
-    sudo: required
-  - rvm: 2.5.1
-    bundler_args: --without development release
-    dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1404-64{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian9-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
   - rvm: 2.5.1
@@ -70,7 +82,19 @@ matrix:
   - rvm: 2.5.1
     bundler_args: --without development release
     dist: trusty
-    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6-nightly BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker} CHECK=beaker
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1604-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker} CHECK=beaker
+    services: docker
+    sudo: required
+  - rvm: 2.5.1
+    bundler_args: --without development release
+    dist: trusty
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=ubuntu1804-64{hypervisor=docker} CHECK=beaker
     services: docker
     sudo: required
 branches:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,7 @@ rsyslog::service_name: rsyslog
 rsyslog::service_status: running
 rsyslog::service_enabled: true
 rsyslog::external_service: false
+rsyslog::use_upstream_repo: false
 
 ## This can be an array of extra "feature" packages to install for rsyslog
 rsyslog::feature_packages: []

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,7 +1,10 @@
 ---
-version: 4
+version: 5
+
+defaults:
+  datadir: data
+  data_hash: yaml_data
 
 hierarchy:
-  - name: "common"
-    backend: yaml
-
+  - name: "Common Data"
+    path: "common.yaml"

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -10,19 +10,21 @@ class rsyslog::base {
   # directly
 
   if $::rsyslog::use_upstream_repo {
-    case $facts['os']['name'] {
-      'Ubuntu': {
-        include ::apt
-        apt::ppa { 'ppa:adiscon/v8-stable': }
+    case $facts['os']['family'] {
+      'Debian': {
+        if $facts['os']['name'] == 'Ubuntu' {
+          include apt
+          apt::ppa { 'ppa:adiscon/v8-stable': }
+        }
       }
-      'RedHat', 'CentOS': {
+      'RedHat': {
         yumrepo { 'upstream_rsyslog':
           ensure   => 'present',
           descr    => 'Adiscon Enterprise Linux rsyslog',
           baseurl  => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch',
           enabled  => '1',
           gpgcheck => '0',
-          gpgkey   => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch'
+          gpgkey   => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch',
         }
       }
       default: { fail("${facts['os']['name']} is not current supported by upstream packages.")}

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -12,16 +12,16 @@ class rsyslog::base {
   if $::rsyslog::use_upstream_repo {
     case $facts['os']['name'] {
       'Ubuntu': {
-        include apt
+        include ::apt
         apt::ppa { 'ppa:adiscon/v8-stable': }
       }
       'RedHat', 'CentOS': {
         yumrepo { 'upstream_rsyslog':
           ensure   => 'present',
-          name     => 'Adiscon Enterprise Linux rsyslog',
+          descr    => 'Adiscon Enterprise Linux rsyslog',
           baseurl  => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch',
           enabled  => '1',
-          gpgcheck => '1',
+          gpgcheck => '0',
           gpgkey   => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch'
         }
       }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -9,6 +9,26 @@ class rsyslog::base {
   # Include the base class in case this class is being called
   # directly
 
+  if $::rsyslog::use_upstream_repo {
+    case $facts['os']['name'] {
+      'Ubuntu': {
+        include apt
+        apt::ppa { 'ppa:adiscon/v8-stable': }
+      }
+      'RedHat', 'CentOS': {
+        yumrepo { 'upstream_rsyslog':
+          ensure   => 'present',
+          name     => 'Adiscon Enterprise Linux rsyslog',
+          baseurl  => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch',
+          enabled  => '1',
+          gpgcheck => '1',
+          gpgkey   => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch'
+        }
+      }
+      default: { fail("${facts['os']['name']} is not current supported by upstream packages.")}
+    }
+  }
+
   if $::rsyslog::manage_package {
     package { $::rsyslog::package_name:
       ensure => $::rsyslog::package_version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,6 +54,7 @@ class rsyslog (
   Boolean $service_enabled,
   Boolean $override_default_config,
   Boolean $manage_package,
+  Boolean $use_upstream_repo,
   Boolean $manage_confdir,
   Boolean $manage_service,
   Boolean $external_service,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,3 +1,4 @@
+# Class that manages Rsyslog Server config
 class rsyslog::server (
   Optional[Hash] $global_config   = {},
   Optional[Hash] $legacy_config   = {},

--- a/metadata.json
+++ b/metadata.json
@@ -44,19 +44,6 @@
       ]
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "11",
-        "12"
-      ]
-    },
-    {
-      "operatingsystem": "OpenSuSE",
-      "operatingsystemrelease": [
-        "13.1"
-      ]
-    },
-    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9"

--- a/metadata.json
+++ b/metadata.json
@@ -11,28 +11,24 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "6",
         "7"
       ]
     },
@@ -68,10 +64,6 @@
     {
       "name": "puppetlabs-apt",
       "version_requirement": ">= 5.0.0 < 7.0.0"
-    },
-    {
-      "name": "puppetlabs-yumrepo_core",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "requirements": [

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,14 @@
     {
       "name": "puppetlabs-concat",
       "version_requirement": ">= 2.0.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">= 5.0.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs-yumrepo_core",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "requirements": [

--- a/spec/acceptance/actions_spec.rb
+++ b/spec/acceptance/actions_spec.rb
@@ -10,11 +10,12 @@ describe 'Rsyslog actions' do
       pp = <<-MANIFEST
       class { 'rsyslog::server':
         actions => {
-          'elasticsearch' => {
-            'type'   => 'elasticsearch',
+          'omfile_all_logs' => {
+            'type'   => 'omfile',
             'config' => {
               'queue.type'           => 'LinkedList',
-              'queue.spoolDirectory' => '/var/log/rsyslog/queue'
+              'queue.spoolDirectory' => '/var/log/rsyslog/queue',
+              'file'                 => '/tmp/log',
             }
           }
         }
@@ -26,7 +27,7 @@ describe 'Rsyslog actions' do
     end
 
     describe file('/etc/rsyslog.d/50_rsyslog.conf') do
-      its(:content) { is_expected.to match(%r{action\(type="elasticsearch"\n.*name="elasticsearch"\n.*queue\.type="LinkedList"\n.*queue\.spoolDirectory="\/var\/log\/rsyslog\/queue"\n.*\)}) }
+      its(:content) { is_expected.to match(%r{# omfile_all_logs\naction\(type="omfile"\n.*name="omfile_all_logs"\n.*queue.type="LinkedList"\n.*queue.spoolDirectory="\/var\/log\/rsyslog\/queue"\n.*file="\/tmp\/log"\n.*\)}) }
     end
   end
 end

--- a/spec/acceptance/base_spec.rb
+++ b/spec/acceptance/base_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper_acceptance'
+
+describe 'Rsyslog base' do
+  before(:context) do
+    cleanup_helper
+  end
+
+  after(:context) do
+    cleanup_helper
+    upstream_cleanup
+  end
+
+  context 'applies with upstream adiscon repo' do
+    it 'applies with repo' do
+      pp = <<-MANIFEST
+      case $facts['os']['name'] {
+        'Ubuntu': {
+          $overrides = true
+          $upstream = true
+        }
+        'CentOS', 'RedHat', 'Scientific': {
+          $overrides = false
+          $upstream = true
+        }
+        default: {
+          $overrides = true
+          $upstream = false
+        }
+      }
+      class { 'rsyslog':
+        use_upstream_repo       => $upstream,
+        override_default_config => $overrides,
+        purge_config_files      => $overrides,
+      }
+      MANIFEST
+
+      apply_manifest(pp, catch_failures: true)
+      apply_manifest(pp, catch_changes: true)
+    end
+  end
+
+  case fact('os.family')
+  when 'RedHat'
+    describe file('/etc/yum.repos.d/upstream_rsyslog.repo') do
+      it { is_expected.to exist }
+    end
+  when 'Ubuntu'
+    describe file("/etc/apt/sources.list.d/adiscon-ubuntu-v8-stable-#{fact('os.distro.codename')}") do
+      it { is_expected.to exist }
+    end
+  end
+end

--- a/spec/acceptance/base_spec.rb
+++ b/spec/acceptance/base_spec.rb
@@ -44,8 +44,9 @@ describe 'Rsyslog base' do
     describe file('/etc/yum.repos.d/upstream_rsyslog.repo') do
       it { is_expected.to exist }
     end
-  when 'Ubuntu'
-    describe file("/etc/apt/sources.list.d/adiscon-ubuntu-v8-stable-#{fact('os.distro.codename')}") do
+  when 'Debian'
+    next if fact('os.name') != 'Ubuntu'
+    describe file("/etc/apt/sources.list.d/adiscon-ubuntu-v8-stable-#{fact('os.distro.codename')}.list") do
       it { is_expected.to exist }
     end
   end

--- a/spec/acceptance/inputs_spec.rb
+++ b/spec/acceptance/inputs_spec.rb
@@ -9,6 +9,10 @@ describe 'Rsyslog inputs' do
     it 'applies with inputs' do
       pp = <<-MANIFEST
       class { 'rsyslog::server':
+        modules => {
+          'imudp'  => {},
+          'imptcp' => {},
+        },
         inputs => {
           'imudp' => {
             'type'  => 'imudp',
@@ -20,6 +24,16 @@ describe 'Rsyslog inputs' do
             'type'  => 'imptcp',
             'config' => {
               'port' => '514',
+            },
+          },
+        },
+        actions => {
+          'default_output' => {
+            'type' => 'omfile',
+            'config' => {
+              'queue.type'           => 'LinkedList',
+              'queue.spoolDirectory' => '/var/log/rsyslog/queue',
+              'file'                 => '/tmp/log',
             },
           },
         },
@@ -40,6 +54,17 @@ describe 'Rsyslog inputs' do
     it 'applies with custom priorities' do
       pp = <<-MANIFEST
 class { 'rsyslog::server':
+        modules => {
+          'imfile' => {
+            'priority' => 5,
+          },
+          'imudp'  => {
+            'priority' => 5,
+          },
+          'imptcp' => {
+            'priority' => 5,
+          },
+        },
         inputs => {
           'imfile' => {
             'priority' => 10,
@@ -68,6 +93,17 @@ class { 'rsyslog::server':
             'config'   => {
               'File' => '/tmp/test-file2',
             },
+          },
+        },
+        actions => {
+          'default_output' => {
+            'priority' => 113,
+            'type'     => 'omfile',
+            'config'   => {
+              'queue.type'           => 'LinkedList',
+              'queue.spoolDirectory' => '/var/log/rsyslog/queue',
+              'file'                 => '/tmp/log',
+            }
           },
         },
       }

--- a/spec/acceptance/rsyslog_spec.rb
+++ b/spec/acceptance/rsyslog_spec.rb
@@ -8,7 +8,18 @@ describe 'Rsyslog' do
 
     it 'applies' do
       pp = <<-MANIFEST
-      class { 'rsyslog': }
+      case $facts['os']['name'] {
+        'Ubuntu': {
+          $overrides = true
+        }
+        'RedHat', 'CentOS', 'Scientific': {
+          $overrides = false
+        }
+      }
+      class { 'rsyslog':
+        override_default_config => $overrides,
+        purge_config_files      => $overrides,
+      }
       MANIFEST
 
       apply_manifest(pp, catch_failures: true)
@@ -18,7 +29,6 @@ describe 'Rsyslog' do
     describe file('/etc/rsyslog.conf') do
       it { is_expected.to be_file }
       it { is_expected.to be_readable }
-      its(:content) { is_expected.to contain('\$IncludeConfig /etc/rsyslog\.d/\*\.conf') }
     end
 
     describe file('/etc/rsyslog.d') do

--- a/spec/acceptance/ruleset_spec.rb
+++ b/spec/acceptance/ruleset_spec.rb
@@ -8,6 +8,21 @@ describe 'Rsyslog::Component::Ruleset' do
     pp = <<-MANIFEST
       class { 'rsyslog::server':
         rulesets => {
+          'action.ruleset.test' => {
+            'rules' => [
+              {
+                action => {
+                  'name'   => 'action.test',
+                  'type'   => 'omfile',
+                  'config' => {
+                    'queue.type'           => 'LinkedList',
+                    'queue.spoolDirectory' => '/var/log/rsyslog/queue',
+                    'file'                 => '/tmp/error_log',
+                  }
+                },
+              }
+            ]
+          },
           'ruleset_eth0_514_test' => {
             'parameters' => {
               'queue.size' => '10000',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,59 +2,64 @@ require 'spec_helper'
 
 describe 'Rsyslog', include_rsyslog: true do
   on_supported_os.each do |os, facts|
-    context 'with defaults for all parameters' do
-      it { is_expected.to contain_class('rsyslog') }
-      it { is_expected.to contain_class('rsyslog::base') }
-    end
+    context "on #{os}" do
+      let(:facts) { facts }
 
-    describe 'Rsyslog::Base' do
-      context 'with defaults' do
-        it { is_expected.to contain_package('rsyslog').with_ensure('installed') }
-        it { is_expected.to contain_file('/etc/rsyslog.d').with_ensure('directory').that_requires('Package[rsyslog]') }
-        it { is_expected.to contain_file('/etc/rsyslog.conf').with_ensure('file') }
-        it { is_expected.to contain_service('rsyslog').with_ensure('running').with_enable(true) }
+      context 'with defaults for all parameters' do
+        it { is_expected.to contain_class('rsyslog') }
+        it { is_expected.to contain_class('rsyslog::base') }
       end
 
-      context 'with package not managed' do
-        let(:params) { { 'manage_package' => false } }
-
-        it { is_expected.not_to contain_package('rsyslog') }
-      end
-
-      context 'with feature packages' do
-        let(:params) { { 'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls] } }
-
-        it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed') }
-        it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed') }
-        it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed') }
-      end
-
-      context 'with upstream packages enabled' do
-        let(:params) { { 'use_upstream_repo' => true } }
-
-        require 'pry'; binding.pry
-        case facts[:os]['name']
-        when 'Ubuntu'
-          it { is_expected.to contain_apt__ppa('ppa:adiscon/v8-stable') }
+      describe 'Rsyslog::Base' do
+        context 'with defaults' do
+          it { is_expected.to contain_package('rsyslog').with_ensure('installed') }
+          it { is_expected.to contain_file('/etc/rsyslog.d').with_ensure('directory').that_requires('Package[rsyslog]') }
+          it { is_expected.to contain_file('/etc/rsyslog.conf').with_ensure('file') }
+          it { is_expected.to contain_service('rsyslog').with_ensure('running').with_enable(true) }
         end
-      end
 
-      context 'with manage_confdir disabled' do
-        let(:params) { { 'manage_confdir' => false } }
+        context 'with package not managed' do
+          let(:params) { { 'manage_package' => false } }
 
-        it { is_expected.not_to contain_file('/etc/rsyslog.d') }
-      end
+          it { is_expected.not_to contain_package('rsyslog') }
+        end
 
-      context 'with override_default_config disabled' do
-        let(:params) { { 'override_default_config' => false } }
+        context 'with feature packages' do
+          let(:params) { { 'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls] } }
 
-        it { is_expected.not_to contain_file('/etc/rsyslog.conf') }
-      end
+          it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed') }
+          it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed') }
+          it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed') }
+        end
 
-      context 'with service disabled' do
-        let(:params) { { 'manage_service' => false } }
+        context "with upstream packages enabled on #{facts[:os]['name']}" do
+          let(:params) { { 'use_upstream_repo' => true } }
 
-        it { is_expected.not_to contain_service('rsyslog') }
+          case facts[:os]['family']
+          when 'Ubuntu'
+            it { is_expected.to contain_apt__ppa('ppa:adiscon/v8-stable') }
+          when 'RedHat'
+            it { is_expected.to contain_yumrepo('upstream_rsyslog') }
+          end
+        end
+
+        context 'with manage_confdir disabled' do
+          let(:params) { { 'manage_confdir' => false } }
+
+          it { is_expected.not_to contain_file('/etc/rsyslog.d') }
+        end
+
+        context 'with override_default_config disabled' do
+          let(:params) { { 'override_default_config' => false } }
+
+          it { is_expected.not_to contain_file('/etc/rsyslog.conf') }
+        end
+
+        context 'with service disabled' do
+          let(:params) { { 'manage_service' => false } }
+
+          it { is_expected.not_to contain_service('rsyslog') }
+        end
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,49 +1,61 @@
 require 'spec_helper'
 
 describe 'Rsyslog', include_rsyslog: true do
-  context 'with defaults for all parameters' do
-    it { is_expected.to contain_class('rsyslog') }
-    it { is_expected.to contain_class('rsyslog::base') }
-  end
-
-  describe 'Rsyslog::Base' do
-    context 'with defaults' do
-      it { is_expected.to contain_package('rsyslog').with_ensure('installed') }
-      it { is_expected.to contain_file('/etc/rsyslog.d').with_ensure('directory').that_requires('Package[rsyslog]') }
-      it { is_expected.to contain_file('/etc/rsyslog.conf').with_ensure('file') }
-      it { is_expected.to contain_service('rsyslog').with_ensure('running').with_enable(true) }
+  on_supported_os.each do |os, facts|
+    context 'with defaults for all parameters' do
+      it { is_expected.to contain_class('rsyslog') }
+      it { is_expected.to contain_class('rsyslog::base') }
     end
 
-    context 'with package not managed' do
-      let(:params) { { 'manage_package' => false } }
+    describe 'Rsyslog::Base' do
+      context 'with defaults' do
+        it { is_expected.to contain_package('rsyslog').with_ensure('installed') }
+        it { is_expected.to contain_file('/etc/rsyslog.d').with_ensure('directory').that_requires('Package[rsyslog]') }
+        it { is_expected.to contain_file('/etc/rsyslog.conf').with_ensure('file') }
+        it { is_expected.to contain_service('rsyslog').with_ensure('running').with_enable(true) }
+      end
 
-      it { is_expected.not_to contain_package('rsyslog') }
-    end
+      context 'with package not managed' do
+        let(:params) { { 'manage_package' => false } }
 
-    context 'with feature packages' do
-      let(:params) { { 'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls] } }
+        it { is_expected.not_to contain_package('rsyslog') }
+      end
 
-      it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed') }
-      it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed') }
-      it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed') }
-    end
+      context 'with feature packages' do
+        let(:params) { { 'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls] } }
 
-    context 'with manage_confdir disabled' do
-      let(:params) { { 'manage_confdir' => false } }
+        it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed') }
+        it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed') }
+        it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed') }
+      end
 
-      it { is_expected.not_to contain_file('/etc/rsyslog.d') }
-    end
+      context 'with upstream packages enabled' do
+        let(:params) { { 'use_upstream_repo' => true } }
 
-    context 'with override_default_config disabled' do
-      let(:params) { { 'override_default_config' => false } }
+        require 'pry'; binding.pry
+        case facts[:os]['name']
+        when 'Ubuntu'
+          it { is_expected.to contain_apt__ppa('ppa:adiscon/v8-stable') }
+        end
+      end
 
-      it { is_expected.not_to contain_file('/etc/rsyslog.conf') }
-    end
+      context 'with manage_confdir disabled' do
+        let(:params) { { 'manage_confdir' => false } }
 
-    context 'with service disabled' do
-      let(:params) { { 'manage_service' => false } }
+        it { is_expected.not_to contain_file('/etc/rsyslog.d') }
+      end
 
-      it { is_expected.not_to contain_service('rsyslog') }
+      context 'with override_default_config disabled' do
+        let(:params) { { 'override_default_config' => false } }
+
+        it { is_expected.not_to contain_file('/etc/rsyslog.conf') }
+      end
+
+      context 'with service disabled' do
+        let(:params) { { 'manage_service' => false } }
+
+        it { is_expected.not_to contain_service('rsyslog') }
+      end
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,15 +10,37 @@ RSpec.configure do |c|
   c.before :suite do
     install_module_on(hosts)
     install_module_dependencies_on(hosts)
+
+    hosts.each do |host|
+      case fact('os.name')
+      when 'Ubuntu'
+        install_package(host, 'software-properties-common')
+      end
+
+      if ENV['BEAKER_PUPPET_COLLECTION'] != 'puppet6'
+        on host, puppet('module', 'uninstall', 'puppetlabs-yumrepo_core', '--force'), acceptable_exit_codes: [0, 1]
+      end
+    end
   end
 end
 
 def cleanup_helper
   pp = <<-CLEANUP_MANIFEST
     package { 'rsyslog': ensure => absent }
-    file { '/etc/rsyslog.d': ensure => absent, purge => true }
+    file { '/etc/rsyslog.d': ensure => absent, purge => true, force => true }
     file { '/etc/rsyslog.conf': ensure => absent }
   CLEANUP_MANIFEST
 
   apply_manifest(pp, catch_failures: true)
+end
+
+def upstream_cleanup
+  if fact('os.name') == 'Ubuntu' # rubocop:disable Style/GuardClause
+    pp = <<-CLEANUP_MANIFEST
+      include ::apt
+      apt::ppa { 'ppa:adiscon/v8-stable': ensure => absent }
+    CLEANUP_MANIFEST
+
+    apply_manifest(pp, catch_failures: true)
+  end
 end


### PR DESCRIPTION
* Added support to use the upstream Adiscon Rsyslog repos maintained by Rsyslog for Ubuntu and EL.
    * Unfortunately, Rsyslog doesn't support other distros, so those distros will continue to use the system packages for the time being.
* Fixed several acceptance tests.
* Removed Ubuntu 14.04 from the travis matrix
* Removed support for EL 6. Due to dependency issues with EL6 and rsyslog, it is difficult to test. We cannot support OSes we can't test.
* Added Ubuntu 18.04  to the Matrix.
* Add Dependent modules for repo management support