### PR TITLE
Add remaining rsyslog module types

### DIFF
--- a/types/modules/input.pp
+++ b/types/modules/input.pp
@@ -1,0 +1,16 @@
+type Rsyslog::Modules::Input = Enum[
+  'im3195',
+  'imfile',
+  'imgssapi',
+  'imjournal',
+  'imkafka',
+  'imklog',
+  'imkmsg',
+  'impstats',
+  'imptcp',
+  'imrelp',
+  'imsolaris',
+  'imtcp',
+  'imupd',
+  'imuxsock',
+]

--- a/types/modules/message.pp
+++ b/types/modules/message.pp
@@ -1,0 +1,16 @@
+type Rsyslog::Modules::Message = Enum[
+  'mmanon',
+  'mmcount',
+  'mmdblookup',
+  'mmexternal',
+  'mmfields',
+  'mmjsonparse',
+  'mmkubernetes',
+  'mmnormalize',
+  'mmpstructdata',
+  'mmrfc5424addhmac',
+  'mmrm1stspace',
+  'mmsequence',
+  'mmsnmptrapd',
+  'mmutf8fix',
+]

--- a/types/modules/parser.pp
+++ b/types/modules/parser.pp
@@ -1,0 +1,9 @@
+type Rsyslog::Modules::Parser = Enum[
+  'pmciscoios',
+  'pmlastmsg',
+  'pmnormalize',
+  'pmnull',
+  'pmrfc3164',
+  'pmrfc3164sd',
+  'pmrfc5424',
+]

--- a/types/modules/string.pp
+++ b/types/modules/string.pp
@@ -1,0 +1,6 @@
+type Rsyslog::Modules::String = Enum[
+  'smfile',
+  'smfwd',
+  'smtradfile',
+  'smtradfwd',
+]


### PR DESCRIPTION
Add remaining built-in rsyslog module types. These will be used and tested in the specific parameters for configuring module config and module calls. These are not to be confused with puppet modules.