### PR TITLE
Fix template output if value is array

### DIFF
--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -9,7 +9,11 @@ module(load="<%=$config_item -%>")
 <% elsif $type == 'external' and empty($config) == false { -%>
 module(load="<%= $config_item -%>" 
      <% $config.each |$key, $value| {-%>
+     <%- if $value =~ Array { -%>
+     <%= $key %>=<%= to_json($value) -%>
+     <%- } else { -%>
      <%= $key %>="<%= $value -%>"
+     <%- } -%>
      <% } %>
 )
 <% } -%>


### PR DESCRIPTION
There are rsyslog config values that accepts an array instead of
string[1]. In such cases the template generated will have a corrupted
output like
 key = "[value1, value2]"
instead of
 key = ["value1", "value2"]

This fixes template output by passing value to to_json{} in stdlib,
which generates valid output in case of an array.

[1] https://www.rsyslog.com/doc/v8-stable/configuration/modules/imtcp.html#permittedpeer

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
