### PR TITLE
base.pp: add final newline to rsyslog.conf

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -79,7 +79,7 @@ class rsyslog::base {
 
     file { $::rsyslog::config_file:
       ensure  => 'file',
-      content => "${message}\n\$IncludeConfig ${::rsyslog::confdir}/*.conf",
+      content => "${message}\n\$IncludeConfig ${::rsyslog::confdir}/*.conf\n",
     }
   }
 


### PR DESCRIPTION
Text files should end with a newline.