### PR TITLE
Add EL 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,11 @@ rsyslog::server::custom_config:
 
 ```
 
+### Known Issues
+
+* Designed specifically for Rsyslog 8+ and the Rainerscript configuration format. Legacy configuration/Rsyslog < 8 support requires the use of the `custom_config` parameter.
+* The upstream repository for EL8 is currently broken and will not work.
+
 ### License
 
 * This module is licensed under Apache 2.0, see LICENSE for more details

--- a/metadata.json
+++ b/metadata.json
@@ -11,25 +11,29 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
Add support for EL8 distributions using the system rsyslog package (8.37). The upstream repo is currently broken for EL8 and has a guard clause in it. This does not include acceptance tests yet either.