### PR TITLE
Force apt::ppa before package

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -14,7 +14,9 @@ class rsyslog::base {
       'Debian': {
         if $facts['os']['name'] == 'Ubuntu' {
           include apt
-          apt::ppa { 'ppa:adiscon/v8-stable': }
+          apt::ppa { 'ppa:adiscon/v8-stable':
+            before => Package[$rsyslog::package_name],
+          }
         }
       }
       'RedHat': {


### PR DESCRIPTION
Forces the configuration of the `apt::ppa` repository before the
installation of packages, so they will be installed in their correct
version.