### PR TITLE
Configure /etc/rsyslog.conf after package installation

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -77,9 +77,14 @@ class rsyslog::base {
       # all configuration is under the rsyslog.d directory
       |EOT
 
+    $_require = $rsyslog::manage_package ? {
+      false   => undef,
+      default => Package[$rsyslog::package_name],
+    }
     file { $rsyslog::config_file:
       ensure  => 'file',
       content => "${message}\n\$IncludeConfig ${rsyslog::confdir}/*.conf\n",
+      require => $_require,
     }
   }
 


### PR DESCRIPTION
This file could be created before packages installation. This commit
forces the configuration of the file after the package installation.

When the file is created empty before package installation, then this action could fail with errors like
```
Error: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install rsyslog' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  liblognorm5
Suggested packages:
  rsyslog-mysql | rsyslog-pgsql rsyslog-doc rsyslog-relp rsyslog-elasticsearch
  rsyslog-mmjsonparse rsyslog-imptcp rsyslog-gnutls rsyslog-openssl
  rsyslog-udpspoof rsyslog-mmrm1stspace rsyslog-mmutf8fix rsyslog-kafka
  rsyslog-omstdout
The following NEW packages will be installed:
  liblognorm5 rsyslog
0 upgraded, 2 newly installed, 0 to remove and 7 not upgraded.
Need to get 62.3 kB/724 kB of archives.
After this operation, 1845 kB of additional disk space will be used.
Get:1 http://ppa.launchpad.net/adiscon/v8-stable/ubuntu bionic/main amd64 liblognorm5 amd64 2.0.6-0adiscon1bionic1 [62.3 kB]
Fetched 62.3 kB in 0s (263 kB/s)
Selecting previously unselected package liblognorm5.
(Reading database ... 89635 files and directories currently installed.)
Preparing to unpack .../liblognorm5_2.0.6-0adiscon1bionic1_amd64.deb ...
Unpacking liblognorm5 (2.0.6-0adiscon1bionic1) ...
Selecting previously unselected package rsyslog.
Preparing to unpack .../rsyslog_8.2001.0-0adiscon1bionic1_amd64.deb ...
Unpacking rsyslog (8.2001.0-0adiscon1bionic1) ...
Setting up liblognorm5 (2.0.6-0adiscon1bionic1) ...
Setting up rsyslog (8.2001.0-0adiscon1bionic1) ...

Configuration file '/etc/rsyslog.conf'
 ==> File on system created by you or by a script.
 ==> File also in package provided by package maintainer.
 ==> Keeping old config file as default.
```
This commit fixes this problem.