### PR TITLE
Let config values be an array in inputs

### DIFF
--- a/templates/input.epp
+++ b/templates/input.epp
@@ -6,6 +6,10 @@ $config
 # <%= $input_name %>
 input(type="<%= $type %>"
 <% $config.each |$k, $v| { -%>
+  <%- if $v =~ Array { -%>
+  <%= $k %>=[ <%= $v.map |$i| { "\"${i}\"" }.join(', ') %> ]
+  <%- } else { -%>
   <%= $k %>="<%= $v %>"
+  <%- } -%>
 <%}-%>
 )


### PR DESCRIPTION
This PR permits an option in an input to be an array.

For example, according to [imkafka documentation](https://www.rsyslog.com/doc/v8-stable/configuration/modules/imkafka.html) when you have more than just one broker configuration is like this:
```
input(type="imkafka" topic="mytopic"
       broker=["localhost:9092",
               "localhost:9093",
               "localhost:9094"]
      )
```
but a code like:
```
rsyslog::config::inputs:
  imkafka:
    type: imkafka
    config:
      topic: mytopic
      consumergroup: mygroup
      broker:
        - localhost:9092
        - localhost:9093
        - localhost:9094
```
creates the config:
```
input(type="imkafka"
  topic="mytopic"
  broker="[localhost:9092, localhost:9093, localhost:9094]"
  consumergroup="mygroup"
)
```
This patch lets options in `config` hash to be an array and be treated like an array
