### PR TITLE
Fix issues with the expression filter keys

### DIFF
--- a/manifests/component/expression_filter.pp
+++ b/manifests/component/expression_filter.pp
@@ -9,7 +9,7 @@ define rsyslog::component::expression_filter (
 
   $content = epp('rsyslog/expression_filter.epp', {
       'filter_name'  => $name,
-      'conditionals' => $conditionals,
+      'cases'        => $conditionals,
   })
 
   rsyslog::generate_concat { "rsyslog::concat::expression_filter::${name}":

--- a/templates/expression_filter.epp
+++ b/templates/expression_filter.epp
@@ -1,13 +1,15 @@
 <%- |
 $filter_name,
-$conditionals
+$cases
 | -%>
 # <%= $filter_name %>
-<%- $conditionals.each |$conditional, $options| { -%>
-  <%- if $conditional == 'else' { -%>
-<%= $conditional %> {
+<%- $cases.each |$case, $options| { -%>
+  <%- if $case =~ /(default|else)/{ -%>
+<%= $case %> {
+  <%- } elsif $case =~ /(main|if)/ { -%>
+<%= "if ${options['expression']} then" %> {
   <%- } else { -%>
-<%= "${conditional} ${options['expression']} then" %> {
+<%= "else if ${options['expression']} then" %> {
   <%-}-%>
 <%- $options['tasks'].each |$task| { -%>
 <%= epp('rsyslog/tasks.epp', { 'tasks' => $task }) -%>

--- a/templates/ruleset.epp
+++ b/templates/ruleset.epp
@@ -15,7 +15,7 @@ ruleset (name="<%= $ruleset_name %>"
     <%- if $key == 'property_filter' { -%>
 <%= epp('rsyslog/property_filter.epp', { 'filter_name' => 'Property-based Filter', 'property' => $params['property'], 'operator' => $params['operator'], 'value' => $params['value'], 'tasks' => $params['tasks']}) %>
     <%- } elsif $key == 'expression_filter' { -%>
-<%= epp('rsyslog/expression_filter.epp', { 'filter_name' => 'Expression-based Filter', 'conditionals' => $params['filter'] }) -%>
+<%= epp('rsyslog/expression_filter.epp', { 'filter_name' => 'Expression-based Filter', 'cases' => $params['filter'] }) -%>
     <%- } else {  %>
 <%= epp('rsyslog/tasks.epp', { 'tasks' => $rule }) -%>
     <%-}-%>


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes an issue with the expression filter template where all `else if` keys would be treated as the same key (as YAML does). Added new documentation and template logic that now looks for user-defined keys that are descriptive to the check, with the exception of the first condition and the last condition, which have specific keywords assigned to them:

First Condition (required):
* `if` - for backwards compatibility
* `main` - Descriptive as the main condition of the filter.
* Required and must use one of the keywords in the YAML or Puppet code.

Last Condition:
* `else` - for backwards compatibility
* `default` - Descriptive as the "default" or "fall through" condition of the filter.
* Required if more than one condition is defined.

#### This Pull Request (PR) fixes the following issues
Fixed #164
