### PR TITLE
add parameter defaults to rsyslog::component::custom_config

### DIFF
--- a/manifests/component/custom_config.pp
+++ b/manifests/component/custom_config.pp
@@ -3,10 +3,10 @@
 # with any of the shipped models.  
 #
 define rsyslog::component::custom_config (
+  String  $content,
   Integer $priority = $rsyslog::custom_priority,
   String  $target = "${name}.conf",
   String  $confdir = $rsyslog::confdir,
-  String  $content,
   String  $filename_part = $name,
 ) {
   include rsyslog

--- a/manifests/component/custom_config.pp
+++ b/manifests/component/custom_config.pp
@@ -3,9 +3,9 @@
 # with any of the shipped models.  
 #
 define rsyslog::component::custom_config (
-  Integer $priority,
-  String  $target,
-  String  $confdir,
+  Integer $priority = $rsyslog::custom_priority,
+  String  $target = "${name}.conf",
+  String  $confdir = $rsyslog::confdir,
   String  $content,
   String  $filename_part = $name,
 ) {


### PR DESCRIPTION
### Pull Request (PR) description
This change gives rsyslog::component::custom_config some parameter defaults, so that it can be used (almost) as easy as rsyslog::snippet from saz/rsyslog:
```
rsyslog::component::custom_config {
    'foobar':
        content => 'if $programname == "foobar" then stop';
}
```
creates `/etc/rsyslog.d/foobar.conf` with this content.

#### This Pull Request (PR) fixes the following issues
Fixes #109 