### PR TITLE
Add Aix support

### DIFF
--- a/data/os/AIX.yaml
+++ b/data/os/AIX.yaml
@@ -1,0 +1,8 @@
+---
+rsyslog::package_name: rsyslog.base
+rsyslog::group_name: system
+rsyslog::service_name: syslogd
+rsyslog::switch_default_syslog: true
+# you will need to fill the source out 
+# aix has no yum like service
+rsyslog::package_source: '<package_location>'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -6,5 +6,7 @@ defaults:
   data_hash: yaml_data
 
 hierarchy:
+  - name: "Operating System"
+    path: "os/%{operatingsystem}.yaml"
   - name: "Common Data"
     path: "common.yaml"

--- a/manifests/component/lookup_table.pp
+++ b/manifests/component/lookup_table.pp
@@ -20,8 +20,8 @@ define rsyslog::component::lookup_table (
   file { "rsyslog::component::lookup_table_json::${title}":
     path    => $_json_file,
     content => inline_template('<%= JSON.pretty_generate @lookup_json %>'),
-    owner   => 'root',
-    group   => 'root',
+    owner   => $rsyslog::owner_name,
+    group   => $rsyslog::group_name,
     mode    => '0644',
   }
 

--- a/manifests/generate_concat.pp
+++ b/manifests/generate_concat.pp
@@ -5,7 +5,7 @@ define rsyslog::generate_concat (
   if $rsyslog::manage_service or $rsyslog::external_service {
     if ! defined(Concat["${confdir}/${target}"]) {
       concat { "${confdir}/${target}":
-        owner  => 'root',
+        owner  => $rsyslog::owner_name,
         notify => Service[$rsyslog::service_name],
         order  => 'numeric',
         mode   => $rsyslog::conf_permissions,
@@ -14,7 +14,7 @@ define rsyslog::generate_concat (
   } else {
     if ! defined(Concat["${confdir}/${target}"]) {
       concat { "${confdir}/${target}":
-        owner => 'root',
+        owner => $rsyslog::owner_name,
         order => 'numeric',
         mode  => $rsyslog::conf_permissions,
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,14 @@
 #   Set the file mode for the rsyslog.d configuration directory.
 # @param global_conf_perms
 #   Set the file mode for the /etc/rsyslog.conf
+# @param owner_name
+#   Set the owner name for rsyslog configuration files.
+# @param group_name
+#   Set the group name for rsyslog configuration files.
+# @param AIX_switch_syslog
+#   Set the rsyslog switch to false.
+# @param package_source
+#   Required for AIX to specify package source.
 #
 class rsyslog (
   String            $confdir,
@@ -115,9 +123,13 @@ class rsyslog (
   Integer           $ruleset_priority,
   Integer           $filter_priority,
   String            $target_file,
+  Optional[Stdlib::Absolutepath] $package_source = undef,
   Stdlib::Filemode  $conf_permissions = '0644',
   Stdlib::Filemode  $confdir_permissions = '0755',
   Stdlib::Filemode  $global_conf_perms = $conf_permissions,
+  String            $owner_name = 'root',
+  String            $group_name = 'root',
+  Boolean           $switch_default_syslog = false,
 ) {
   if $manage_service == true and $external_service == true {
     fail('manage_service and external_service cannot be set at the same time!')

--- a/metadata.json
+++ b/metadata.json
@@ -54,6 +54,13 @@
       "operatingsystemrelease": [
         "32"
       ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemrelease": [
+        "7.1",
+        "7.2"
+      ]
     }
   ],
   "dependencies": [


### PR DESCRIPTION
  * Previously this module kinda supported AIX but had a
    few issues.  This code adds better support and allows
    the user to control how the rsyslog package is installed
    and where from.  AIX is still considered experimental but
    it works on several systems tested.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
