### PR TITLE
WIP: Add variables for conf_owner_name and conf_group_name for OS' that don't use root as group. owner_name for completeness 

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,7 @@
 ---
 rsyslog::confdir: /etc/rsyslog.d
+rsyslog::conf_owner_name: root
+rsyslog::conf_group_name: root
 rsyslog::package_name: rsyslog
 rsyslog::package_version: installed
 rsyslog::manage_package: true

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -38,8 +38,8 @@ class rsyslog::base {
   if $rsyslog::manage_confdir {
     file { $rsyslog::confdir:
       ensure  => directory,
-      owner   => 'root',
-      group   => 'root',
+      owner   => $rsyslog::conf_owner_name,
+      group   => $rsyslog::conf_group_name,
       mode    => $rsyslog::confdir_permissions,
       purge   => $rsyslog::purge_config_files,
       recurse => $rsyslog::purge_config_files,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -81,6 +81,10 @@
 #   Target file to insert configuration into.
 # @param conf_permissions
 #   Set the file mode for the generated configuration files.
+# @param conf_owner_name
+#   Set the owner for the rsyslog.d configuration directory and related files.
+# @param conf_group_name
+#   Set the group for the rsyslog.d configuration directory and related files.
 # @param confdir_permissions
 #   Set the file mode for the rsyslog.d configuration directory.
 # @param global_conf_perms
@@ -88,6 +92,8 @@
 #
 class rsyslog (
   String            $confdir,
+  String            $conf_owner_name,
+  String            $conf_group_name,
   String            $package_name,
   String            $package_version,
   String            $config_file,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
