### PR TITLE
Restart rsyslog if feature_packages are installed

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -28,11 +28,15 @@ class rsyslog::base {
     }
   }
 
-  if $rsyslog::feature_packages {
-    package { $rsyslog::feature_packages:
-      ensure  => installed,
-      require => Package[$rsyslog::package_name],
-    }
+  $feature_packages_parms = $rsyslog::manage_service ? {
+    true    => { 'notify' => Service[$rsyslog::service_name], },
+    default => {},
+  }
+
+  package { $rsyslog::feature_packages:
+    ensure  => installed,
+    require => Package[$rsyslog::package_name],
+    *       => $feature_packages_parms,
   }
 
   if $rsyslog::manage_confdir {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -27,9 +27,9 @@ describe 'Rsyslog', include_rsyslog: true do
         context 'with feature packages' do
           let(:params) { { 'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls] } }
 
-          it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed') }
-          it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed') }
-          it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed') }
+          it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed').that_notifies('Service[rsyslog]') }
+          it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed').that_notifies('Service[rsyslog]') }
+          it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed').that_notifies('Service[rsyslog]') }
         end
 
         context "with upstream packages enabled on #{facts[:os]['name']}" do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -32,6 +32,19 @@ describe 'Rsyslog', include_rsyslog: true do
           it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed').that_notifies('Service[rsyslog]') }
         end
 
+        context 'with feature packages and service disabled' do
+          let(:params) do
+            {
+              'feature_packages' => %w[rsyslog-relp rsyslog-mmnormalize rsyslog-gnutls],
+              'manage_service' => false,
+            }
+          end
+
+          it { is_expected.to contain_package('rsyslog-relp').with_ensure('installed').that_notifies('Service[rsyslog]') }
+          it { is_expected.to contain_package('rsyslog-mmnormalize').with_ensure('installed').that_notifies('Service[rsyslog]') }
+          it { is_expected.to contain_package('rsyslog-gnutls').with_ensure('installed').that_notifies('Service[rsyslog]') }
+        end
+
         context "with upstream packages enabled on #{facts[:os]['name']}" do
           let(:params) { { 'use_upstream_repo' => true } }
 


### PR DESCRIPTION
Setup rsyslog so that if any $feature_packages are given rsyslog will
restart after those $feature_packages are installed.

Forcing a restart of rsyslog after installation of any $feature_packages
are installed is important if you have an rsyslog config that is not
valid without the additional package from $feature_packages in place.