### PR TITLE
Add CentOS 9 to supported operating systems

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -18,7 +18,7 @@ class rsyslog::base {
           gpgkey   => 'http://rpms.adiscon.com/v8-stable/epel-$releasever/$basearch',
         }
       }
-      default: { fail("${facts['os']['name']} is not current supported by upstream packages.") }
+      default: { fail("${facts['os']['name']} is not currently supported by upstream packages.") }
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/spec/acceptance/base_spec.rb
+++ b/spec/acceptance/base_spec.rb
@@ -20,7 +20,11 @@ describe 'Rsyslog base' do
           $overrides = true
           $upstream = true
         }
-        'CentOS', 'RedHat', 'Scientific', 'Fedora': {
+        'CentOS', 'RedHat': {
+          $overrides = false
+          $upstream = ( Integer($facts['os']['release']['major']) < 9 )
+        }
+        'Scientific', 'Fedora': {
           $overrides = false
           $upstream = true
         }
@@ -43,8 +47,10 @@ describe 'Rsyslog base' do
 
   case fact('os.family')
   when 'RedHat'
-    describe file('/etc/yum.repos.d/upstream_rsyslog.repo') do
-      it { is_expected.to exist }
+    if fact('os.release.major').to_i < 9
+      describe file('/etc/yum.repos.d/upstream_rsyslog.repo') do
+        it { is_expected.to exist }
+      end
     end
   when 'Debian'
     next if fact('os.name') != 'Ubuntu'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -41,7 +41,7 @@ describe 'Rsyslog', include_rsyslog: true do
           when 'Ubuntu'
             it { is_expected.to contain_apt__ppa('ppa:adiscon/v8-stable') }
           when 'RedHat'
-            it { is_expected.to contain_yumrepo('upstream_rsyslog') }
+            it { is_expected.to contain_yumrepo('upstream_rsyslog') } if facts[:os]['release']['major'].to_i < 9
           end
         end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,6 +10,7 @@ end
 
 def cleanup_helper
   pp = <<-CLEANUP_MANIFEST
+    package { 'rsyslog-logrotate': ensure => absent }
     package { 'rsyslog': ensure => absent }
     file { '/etc/rsyslog.d': ensure => absent, purge => true, force => true }
     file { '/etc/rsyslog.conf': ensure => absent }


### PR DESCRIPTION
#### Pull Request (PR) description
This change adds CentOS Stream 9 (aka CentOS 9) to supported operating
systems.

#### This Pull Request (PR) fixes the following issues
N/A