### PR TITLE
Add boolean variable to change behavior of multi-line actions in conf…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -146,6 +146,7 @@ The following parameters are available in the `rsyslog` class:
 * [`legacy_config_priority`](#-rsyslog--legacy_config_priority)
 * [`template_priority`](#-rsyslog--template_priority)
 * [`action_priority`](#-rsyslog--action_priority)
+* [`dont_linebreak_actions`](#-rsyslog--dont_linebreak_actions)
 * [`input_priority`](#-rsyslog--input_priority)
 * [`custom_priority`](#-rsyslog--custom_priority)
 * [`main_queue_priority`](#-rsyslog--main_queue_priority)
@@ -279,6 +280,14 @@ Set the global ordering of template configuration in rsyslog.
 Data type: `Integer`
 
 Set the global ordering of action configuration in rsyslog.
+
+##### <a name="-rsyslog--dont_linebreak_actions"></a>`dont_linebreak_actions`
+
+Data type: `Boolean`
+
+Ensure that all action options are placed on a single line.
+
+Default value: `false`
 
 ##### <a name="-rsyslog--input_priority"></a>`input_priority`
 
@@ -654,6 +663,7 @@ The following parameters are available in the `rsyslog::component::action` defin
 * [`target`](#-rsyslog--component--action--target)
 * [`confdir`](#-rsyslog--component--action--confdir)
 * [`type`](#-rsyslog--component--action--type)
+* [`dont_linebreak_actions`](#-rsyslog--component--action--dont_linebreak_actions)
 * [`config`](#-rsyslog--component--action--config)
 * [`facility`](#-rsyslog--component--action--facility)
 * [`format`](#-rsyslog--component--action--format)
@@ -681,6 +691,14 @@ Data type: `String`
 Data type: `String`
 
 
+
+##### <a name="-rsyslog--component--action--dont_linebreak_actions"></a>`dont_linebreak_actions`
+
+Data type: `Boolean`
+
+
+
+Default value: `$rsyslog::dont_linebreak_actions`
 
 ##### <a name="-rsyslog--component--action--config"></a>`config`
 

--- a/manifests/component/action.pp
+++ b/manifests/component/action.pp
@@ -3,6 +3,7 @@ define rsyslog::component::action (
   String $target,
   String $confdir,
   String $type,
+  Boolean $dont_linebreak_actions = $rsyslog::dont_linebreak_actions,
   Hash $config = {},
   String[1] $facility = 'default',
   String[1] $format = '<%= $content %>'
@@ -10,10 +11,11 @@ define rsyslog::component::action (
   include rsyslog
 
   $content = epp('rsyslog/action.epp', {
-      'action_name' => $name,
-      'type'        => $type,
-      'facility'    => $facility,
-      'config'      => $config,
+      'action_name'            => $name,
+      'type'                   => $type,
+      'facility'               => $facility,
+      'config'                 => $config,
+      'dont_linebreak_actions' => $dont_linebreak_actions,
   })
 
   rsyslog::generate_concat { "rsyslog::concat::action::${title}":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,8 @@
 #   Set the global ordering of template configuration in rsyslog.
 # @param action_priority
 #   Set the global ordering of action configuration in rsyslog.
+# @param dont_linebreak_actions
+#   Ensure that all action options are placed on a single line.
 # @param input_priority
 #   Set the global ordering of input configuration in rsyslog.
 # @param custom_priority
@@ -118,6 +120,7 @@ class rsyslog (
   Stdlib::Filemode  $conf_permissions = '0644',
   Stdlib::Filemode  $confdir_permissions = '0755',
   Stdlib::Filemode  $global_conf_perms = $conf_permissions,
+  Boolean           $dont_linebreak_actions = false,
 ) {
   if $manage_service == true and $external_service == true {
     fail('manage_service and external_service cannot be set at the same time!')

--- a/spec/defines/component/action_spec.rb
+++ b/spec/defines/component/action_spec.rb
@@ -18,6 +18,7 @@ describe 'Rsyslog::Component::Action', include_rsyslog: true do
             type: 'omelasticsearch',
             priority: 40,
             target: '50_rsyslog.conf',
+            dont_linebreak_actions: false,
             confdir: '/etc/rsyslog.d',
             config: {
               'queue.type' => 'linkedlist',
@@ -49,6 +50,7 @@ describe 'Rsyslog::Component::Action', include_rsyslog: true do
             priority: 40,
             target: '50_rsyslog.conf',
             confdir: '/etc/rsyslog.d',
+            dont_linebreak_actions: false,
             facility: 'kern.*',
             config: {
               'dynaFile' => 'remoteKern'
@@ -67,6 +69,7 @@ describe 'Rsyslog::Component::Action', include_rsyslog: true do
             type: 'omelasticsearch',
             priority: 40,
             target: '50_rsyslog.conf',
+            dont_linebreak_actions: false,
             confdir: '/etc/rsyslog.d',
             facility: '*.*',
             config: {

--- a/templates/action.epp
+++ b/templates/action.epp
@@ -2,7 +2,7 @@
 $action_name,
 $type,
 $facility,
-Boolean $dont_linebreak_actions = false,
+Boolean $dont_linebreak_actions,
 $config
 | -%>
 # <%= $action_name %>

--- a/templates/action.epp
+++ b/templates/action.epp
@@ -2,11 +2,12 @@
 $action_name,
 $type,
 $facility,
+Boolean $dont_linebreak_actions = false,
 $config
 | -%>
 # <%= $action_name %>
-<% if $facility != "default" and size($config) < 3 { -%>
-  <%= sprintf( '%-30s %s%s%s', $facility, 'action(type="',$type,'" ' )-%>
+<% if $facility != "default" and size($config) < 3 or $dont_linebreak_actions { -%>
+  <%= sprintf('%-30s action(type="%s" ', $facility, $type) -%>
   <%  if $config { -%>
     <% $config.each |$k, $v| { -%> <%= $k -%>="<%= $v -%>" <% }-%>)
   <%-}%>

--- a/templates/tasks.epp
+++ b/templates/tasks.epp
@@ -12,7 +12,7 @@ $tasks
     <%}-%>
   <%- } elsif $config == 'action' { -%>
     <%- if ! $cfgval['facility'] or $cfgval['facility'] == '' { $facility = 'default' } else { $facility = $cfgval['facility'] } -%>
-  <%= epp('rsyslog/action.epp', { 'action_name' => $cfgval['name'], 'type' => $cfgval['type'], 'facility' => $facility, 'config' => $cfgval['config'],}) %>
+  <%= epp('rsyslog/action.epp', { 'action_name' => $cfgval['name'], 'type' => $cfgval['type'], 'facility' => $facility, 'config' => $cfgval['config'], 'dont_linebreak_actions' => $cfgval['dont_linebreak_actions'], }) %>
   <%-} elsif $config == 'stop' { -%>
   stop
   <%} elsif $config == 'exec' { -%>


### PR DESCRIPTION
Added a boolean variable to control the multi-line behavior of the action module.  If rsyslog::dont_linebreak_actions == TRUE then all the options in the action will be on a single line.

This behavior might be necessary if you have CIS or STIG scans on your /etc/rsyslog.d configuration files that are looking for settings on a single line such as:

`^\s*([^#]+\s+)?action\(([^#]+\s+)?\btarget="?[^#"]+"?\b
`
and

`^\s*\*\.\*\s+@
`
These regexs will fail even if the configuration is correct but spans multiple lines.