### PR TITLE
Fix typo for `inputs` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,9 +629,11 @@ Puppet examples:
 ```puppet
 class { 'rsyslog:config':
   'inputs' => {
-    'type'   => 'imudp',
-    'config' => {
-      'port' => '514'
+    'imudp' => {
+      'type'   => 'imudp',
+      'config' => {
+        'port' => '514'
+      }
     }
   }
 }
@@ -650,6 +652,7 @@ rsyslog::config::inputs:
 will produce
 
 ```
+# imdup
 input(type="imudp"
   port="514"
 )


### PR DESCRIPTION
#### Pull Request (PR) description
The `rsyslog::config::inputs` section of the README had a typo in its puppet example. The Hiera example is already correct.
In the _will produce_ part, a comment was missing.

#### This Pull Request (PR) fixes the following issues
n/a