### PR TITLE
Minor fix for EPP template action.epp. Replace `is_array()` with `Array[Any]`

### DIFF
--- a/templates/action.epp
+++ b/templates/action.epp
@@ -26,7 +26,7 @@ action(type="<%= $type %>"
 <%}-%>
 <% if $config { -%>
   <% $config.each |$k, $v| { -%>
-  <%- if is_array($v) { -%>
+  <% if $v =~ Array[Any] { -%>
   <%= $k %>=<%= join(["[\"", join($v, '", "'), "\"]"], "")  %>
   <%- } else { -%>
   <%= $k %>="<%= $v %>"


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Minor deprecation fix for EPP template action.epp. Replace `is_array()` with `Array[Any]` Symptom looks like:

```
my-server: This method is deprecated, please use match expressions with Stdlib::Compat::Array instead. They are described at https://docs.puppet.com/puppet/latest/reference/lang_data_type.html#match-expressions. at ["/home/thejambavan/git/bolt/.modules/rsyslog/templates/action.epp", 29]:["/home/thejambavan/git/bolt/.modules/rsyslog/templates/action.epp", 28]
```

#### This Pull Request (PR) fixes the following issues

Fixes #189 