### PR TITLE
Fix lookup_tables typo in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,7 @@ Puppet example with lookup tables:
 class { 'rsyslog::config':
   'lookup_tables' => {
     'srv-map' => {
-      'lookup_json' => {
+      'lookup_json'   => {
         'version'  => 1,
         'nolookup' => 'unk',
         'type'     => 'string',
@@ -1051,9 +1051,9 @@ class { 'rsyslog::config':
             'value' => 'linux'
           }
         ],
-        'lookup_file'   => '/etc/rsyslog.d/tables/srv-map.json',
-        'reload_on_hup' => true
-      }
+      },
+      'lookup_file'   => '/etc/rsyslog.d/tables/srv-map.json',
+      'reload_on_hup' => true
     }
   },
   'rulesets' => {
@@ -1112,8 +1112,8 @@ rsyslog::config::lookup_tables:
           value: 'windows'
         - index: '192.168.255.12'
           value: 'linux'
-      lookup_file: '/etc/rsyslog.d/tables/srv-map.json'
-      reload_on_hup: true
+    lookup_file: '/etc/rsyslog.d/tables/srv-map.json'
+    reload_on_hup: true
 rsyslog::config::rulesets:
   ruleset_lookup_set_windows_by_ip:
     rules:


### PR DESCRIPTION
#### Pull Request (PR) description
The `rsyslog::config::rulesets` section of the README has a typo in its example with a lookup table (both in puppet and hiera example).
The `lookup_file` and `reload_on_hup` parameters should not be in the `lookup_json` hash, but directly in the hash of the table.

Note that examples in section `rsyslog::config::lookup_tables` are already correct.

#### This Pull Request (PR) fixes the following issues
n/a
