### PR TITLE
Fix `global_config` rendering

### DIFF
--- a/manifests/config/global.pp
+++ b/manifests/config/global.pp
@@ -13,7 +13,7 @@ class rsyslog::config::global {
   }
 
   #create a hash just with the non legacy type value
-  $newtype = $rsyslog::config::global_config.filter |$key, $value| { ! 'type' in $value }
+  $newtype = $rsyslog::config::global_config.filter |$key, $value| { ! ('type' in $value) }
 
   #flatten the nested hash of hashes to one single hash
   $flattendata = $newtype.keys.reduce({}) |$memo, $key| { $memo + { $key => $newtype[$key]["value"] } }


### PR DESCRIPTION
The ! has higher precedence than the `in` operator.

Fixes #223.
