### PR TITLE
Fix CI on OracleLinux

### DIFF
--- a/spec/acceptance/base_spec.rb
+++ b/spec/acceptance/base_spec.rb
@@ -20,7 +20,7 @@ describe 'Rsyslog base' do
           $overrides = true
           $upstream = true
         }
-        'CentOS', 'RedHat': {
+        'CentOS', 'OracleLinux', 'RedHat': {
           $overrides = false
           $upstream = ( Integer($facts['os']['release']['major']) < 9 )
         }

--- a/spec/acceptance/rsyslog_spec.rb
+++ b/spec/acceptance/rsyslog_spec.rb
@@ -14,7 +14,7 @@ describe 'Rsyslog' do
         'Ubuntu': {
           $overrides = true
         }
-        'RedHat', 'CentOS', 'Scientific', 'Fedora': {
+        'RedHat', 'CentOS', 'Scientific', 'Fedora', 'OracleLinux': {
           $overrides = false
         }
       }


### PR DESCRIPTION
OracleLinux is a RedHat derivative. It was added to the test matrix but we are missing some conditions in the tests.