### PR TITLE
Update supported Fedora version to 38

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "32"
+        "38"
       ]
     }
   ],

--- a/spec/acceptance/actions_spec.rb
+++ b/spec/acceptance/actions_spec.rb
@@ -10,7 +10,7 @@ describe 'Rsyslog actions' do
   context 'basic action' do
     it 'applies with action' do
       pp = <<-MANIFEST
-      if $facts['os']['name'] == 'Fedora' and $facts['os']['release']['full'] == 32 {
+      if $facts['os']['name'] == 'Fedora' {
         package { 'rsyslog-elasticsearch': ensure => installed }
       }
 


### PR DESCRIPTION
Fedora 32 went EOL long ago. Fedora 37 is EOL in three months, so might as well only list Fedora 38 at this point.