### PR TITLE
drop support for scientific linux 8 -- sl8 never existed

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -34,8 +34,7 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {


### PR DESCRIPTION
This is a `bug` instead of a breaking change as sl8 never existed and no supported platform is being removed. This is fixing a bug with the module's metadata.