### PR TITLE
base: rainerscript replacement for `$IncludeConfig`

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -58,7 +58,7 @@ class rsyslog::base {
 
     file { $rsyslog::config_file:
       ensure  => file,
-      content => "${message}\n\$IncludeConfig ${rsyslog::confdir}/*.conf\n",
+      content => "${message}\ninclude(file=\"${rsyslog::confdir}/*.conf\" mode=\"optional\")\n",
       mode    => $rsyslog::global_conf_perms,
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Makes use of advanced/rainerscript format in base.pp to replace the legacy IncludeConfig statement.

