### PR TITLE
Allow overriding of the `Include` directive in the `/etc/rsyslog.conf` file to support older versions of `rsyslogd`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -157,6 +157,7 @@ The following parameters are available in the `rsyslog` class:
 * [`conf_permissions`](#-rsyslog--conf_permissions)
 * [`confdir_permissions`](#-rsyslog--confdir_permissions)
 * [`global_conf_perms`](#-rsyslog--global_conf_perms)
+* [`config_file_include`](#-rsyslog--config_file_include)
 * [`parser_priority`](#-rsyslog--parser_priority)
 
 ##### <a name="-rsyslog--confdir"></a>`confdir`
@@ -349,6 +350,14 @@ Data type: `Stdlib::Filemode`
 Set the file mode for the /etc/rsyslog.conf
 
 Default value: `$conf_permissions`
+
+##### <a name="-rsyslog--config_file_include"></a>`config_file_include`
+
+Data type: `String`
+
+Override the include directive in the /etc/rsyslog.conf file.
+
+Default value: `"include(file=\"${rsyslog::confdir}/*.conf\" mode=\"optional\")"`
 
 ##### <a name="-rsyslog--parser_priority"></a>`parser_priority`
 

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -58,7 +58,7 @@ class rsyslog::base {
 
     file { $rsyslog::config_file:
       ensure  => file,
-      content => "${message}\ninclude(file=\"${rsyslog::confdir}/*.conf\" mode=\"optional\")\n",
+      content => "${message}\n${rsyslog::config_file_include}\n",
       mode    => $rsyslog::global_conf_perms,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,6 +85,8 @@
 #   Set the file mode for the rsyslog.d configuration directory.
 # @param global_conf_perms
 #   Set the file mode for the /etc/rsyslog.conf
+# @param config_file_include 
+#   Override the include directive in the /etc/rsyslog.conf file.
 #
 class rsyslog (
   String            $confdir,
@@ -118,6 +120,7 @@ class rsyslog (
   Stdlib::Filemode  $conf_permissions = '0644',
   Stdlib::Filemode  $confdir_permissions = '0755',
   Stdlib::Filemode  $global_conf_perms = $conf_permissions,
+  String            $config_file_include = "include(file=\"${rsyslog::confdir}/*.conf\" mode=\"optional\")",
 ) {
   if $manage_service == true and $external_service == true {
     fail('manage_service and external_service cannot be set at the same time!')


### PR DESCRIPTION
## Affected Puppet, Ruby, OS and module versions/distributions

- Puppet:  puppet-agent-7.33.0-1.el7.x86_64
- Distribution:   Red Hat Enterprise Linux Server release 7.9 (Maipo)
- Module version:  [Commit 40440a8](https://github.com/voxpupuli/puppet-rsyslog/commit/40440a8adf609d824402dba2bcf4811b61e648c4)

## What are you seeing

The module incorrectly assumes that the [include()](https://www.rsyslog.com/doc/rainerscript/include.html) object is supported on rsyslog without first checking (or providing an override) for an appropriate version of rsyslog.

## What behaviour did you expect instead

This module uses the new syntax of `include()` instead of the older `$IncludeConfig`.  The include() syntax is supported only on [rsyslog > 8.33.0](https://www.rsyslog.com/doc/rainerscript/include.html).

## Output log

```
syslogd[39175]: action 'include' treated as ':omusrmsg:include' - please use ':omusrmsg:include' syntax instead, 'include' will not be supported in the future [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2184 ]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: warnings occured in file '/etc/rsyslog.conf' around line 5 [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: invalid character '(' - is there an invalid escape sequence somewhere? [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]
syslogd[39175]: action 'file' treated as ':omusrmsg:file' - please use ':omusrmsg:file' syntax instead, 'file' will not be supported in the future [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2184 ]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: warnings occured in file '/etc/rsyslog.conf' around line 5 [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: invalid character '=' - is there an invalid escape sequence somewhere? [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: invalid character '"' - is there an invalid escape sequence somewhere? [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]
syslogd[39175]: invalid character in selector line - ';template' expected [v8.24.0-57.el7_9.3]
syslogd[39175]: error during parsing file /etc/rsyslog.conf, on or before line 5: errors occured in file '/etc/rsyslog.conf' around line 5 [v8.24.0-57.el7_9.3 try http://www.rsyslog.com/e/2207 ]

```


## Any additional information you'd like to impart

The module should do one of the following:

1.  check for the version of rsyslog RPM that's currently installed
2.  provide a way to override the (current) default syntax of include().
3.  leverage hiera data to grab the major os version of the operating system and apply appropriate "include" directives.

The latest version of rsyslog available for RHEL7 is rsyslog-8.24.0-57.el7_9.3.x86_64.rpm.

@m8t