### PR TITLE
Notify the service when there is a change in the config_file

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -62,6 +62,10 @@ class rsyslog::base {
       mode    => $rsyslog::global_conf_perms,
     }
 
+    if $rsyslog::manage_service {
+      File[$rsyslog::config_file] ~> Service[$rsyslog::service_name]
+    }
+
     if $rsyslog::manage_package {
       Package[$rsyslog::package_name] -> File[$rsyslog::config_file]
     }


### PR DESCRIPTION
Hello, I would like to send the PR

#### Pull Request (PR) description
When $rsyslog::config_file changes, the rsyslog service doesn't restart. The PR fixes it, adding a notification.
