### PR TITLE
puppetlabs/apt: Allow 11.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 5.0.0 < 11.0.0"
+      "version_requirement": ">= 5.0.0 < 12.0.0"
     },
     {
       "name": "puppetlabs-concat",


### PR DESCRIPTION
-->
#### Pull Request (PR) description
<!--
puppetlabs-apt is now at version 11.2.0, requesting requirement goes to 12
-->

#### This Pull Request (PR) fixes the following issues
<!--
Brings dependencies to the latest version for other target modules
-->
