### PR TITLE
Puppet 8+ compat support: require stdlib 9, and switch to use `stdlib::to_json`

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.25.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "requirements": [

--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -11,7 +11,7 @@ module(load="<%= $config_item -%>"
      <% $config.each |$key, $value| {-%>
      <%- if $value =~ Array { -%>
      <%= $key %>=<%= stdlib::to_json($value) -%>
-<%- } else { -%>
+     <%- } else { -%>
      <%= $key %>="<%= $value -%>"
      <%- } -%>
      <% } %>

--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -10,7 +10,11 @@ module(load="<%=$config_item -%>")
 module(load="<%= $config_item -%>" 
      <% $config.each |$key, $value| {-%>
      <%- if $value =~ Array { -%>
+     <%- if defined('stdlib::to_json') { -%>
+     <%= $key %>=<%= stdlib::to_json($value) -%>
+     <%- } else { -%>
      <%= $key %>=<%= to_json($value) -%>
+     <%- } -%>
      <%- } else { -%>
      <%= $key %>="<%= $value -%>"
      <%- } -%>

--- a/templates/modules.epp
+++ b/templates/modules.epp
@@ -10,12 +10,8 @@ module(load="<%=$config_item -%>")
 module(load="<%= $config_item -%>" 
      <% $config.each |$key, $value| {-%>
      <%- if $value =~ Array { -%>
-     <%- if defined('stdlib::to_json') { -%>
      <%= $key %>=<%= stdlib::to_json($value) -%>
-     <%- } else { -%>
-     <%= $key %>=<%= to_json($value) -%>
-     <%- } -%>
-     <%- } else { -%>
+<%- } else { -%>
      <%= $key %>="<%= $value -%>"
      <%- } -%>
      <% } %>


### PR DESCRIPTION
#### Pull Request (PR) description
In openvox 8, using `to_json` emits a deprecation warning:

```Puppet This function is deprecated, please use stdlib::to_json instead. at ["/etc/puppetlabs/code/modules/rsyslog/templates/modules.epp", 13]```

This patch changes the use of to_json in modules.epp so that it uses stdlib::to_json, making deprecation warnings go away :)

Stdlib 9 is now required.

#### This Pull Request (PR) fixes the following issues
n/a