### PR TITLE
Re-add RHEL 8 as a supported platform, as accidentally removed

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,7 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "8",
         "9"
       ]
     },


### PR DESCRIPTION
PR 283 reordered entries in the `metadata.json` file and accidentally removed RedHat 8 from the list of supported platforms.

This PR re-adds this.

#### This Pull Request (PR) fixes the following issues
n/a
